### PR TITLE
[feat] add optional geolocation field in NFT router, model and schema

### DIFF
--- a/src/controllers/nftController.ts
+++ b/src/controllers/nftController.ts
@@ -64,7 +64,8 @@ export const mintNFT = async (
         Body: {
             channel_user_id: string;
             url: string,
-            mensaje: string
+            mensaje: string,
+            geolocation?: string,
         };
     }>,
     reply: FastifyReply
@@ -95,7 +96,8 @@ export const mintNFT = async (
         trxId: data.transactionHash,
         metadata: {
             image_url: url,
-            description: mensaje
+            description: mensaje,
+            geolocation: request.body.geolocation || null
         }
     });
 

--- a/src/models/nft.ts
+++ b/src/models/nft.ts
@@ -9,6 +9,7 @@ export interface INFT extends Document {
   metadata: {
     image_url: string;
     description: string;
+    geolocation?: string;
   };
 }
 
@@ -20,7 +21,8 @@ const NFTSchema = new Schema<INFT>({
   trxId: { type: String, required: true },
   metadata: {
     image_url: { type: String, required: true },
-    description: { type: String, required: true }
+    description: { type: String, required: true },
+    geolocation: { type: String, required: false }
   }
 });
 


### PR DESCRIPTION
**Rama**: `feature/add_geolocation`

---

## Descripción

Este PR introduce los siguientes cambios:

1. **Interface de NFT**: Se agregó el parámetro `geolocation` como opcional en el interface del NFT para permitir incluir datos de geolocalización cuando sea necesario.

2. **Esquema de Mongo**: Se actualizó el esquema de MongoDB añadiendo `geolocation` como un campo opcional, garantizando la compatibilidad con el nuevo interface del NFT.

3. **Body de la Ruta**: Se incluyó el parámetro `geolocation` como opcional en el cuerpo de la solicitud de la ruta correspondiente, permitiendo a los clientes enviar datos de geolocalización al crear o actualizar NFTs.

4. **Función Chatizalo-Chatterpay**: Junto a @mpfeaur, se modificó la función de Chatizalo-Chatterpay para adaptarla a los cambios realizados y mejorar su funcionalidad.

---