### PR TITLE
[fix] default chain id for transactions

### DIFF
--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -313,7 +313,7 @@ export const makeTransaction = async (
             toUser,
             token,
             amount,
-            parseInt(chain_id, 10) ?? networkChainIds.default,
+            chain_id ? parseInt(chain_id, 10) : networkChainIds.default,
         );
 
         return await returnSuccessResponse(reply, executionStatus);


### PR DESCRIPTION
Testing with chatizalo, the bot is passing the make transaction endpoint without the chain_id value, so I've adapted the endpoint to work with that