### PR TITLE
Remove CORS restriction

### DIFF
--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -1,3 +1,4 @@
+import cors from '@fastify/cors';
 import rateLimit from '@fastify/rate-limit';
 import Fastify, { FastifyInstance } from 'fastify';
 
@@ -18,6 +19,13 @@ export async function startServer(): Promise<FastifyInstance> {
         ignoreDuplicateSlashes: true,
         ignoreTrailingSlash: true,
         logger: true,
+    });
+
+    await server.register(cors, {
+        origin: '*',
+        methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
+        allowedHeaders: ['Content-Type', 'Authorization'],
+        credentials: true
     });
 
     await server.register(rateLimit, {


### PR DESCRIPTION
## Description 
Closes #174 

Due to ETH Global we need to remove temporally the CORS restriction in order to perform the connect and business management requests
