### PR TITLE
merge fix/cloud-build into develop

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -109,7 +109,7 @@ steps:
       'FRONTEND_TOKEN', 
       'PRIVATE_KEY', 
       'SIGNING_KEY',
-      'PUSH_CHANNEL_PRIVATE_KEY'.
+      'PUSH_CHANNEL_PRIVATE_KEY',
       'MANTECA_API_KEY'
     ]
 


### PR DESCRIPTION
- [build] 🐛 fix Cloud Build error caused by '.' instead of ','
