### PR TITLE
Feat: Testnet pool adjustment based on ether price, removed price protection on testnet

### DIFF
--- a/scripts/swap_debug/adjust_pool.ts
+++ b/scripts/swap_debug/adjust_pool.ts
@@ -4,30 +4,30 @@
  * currently based on Ethereum's price from Coingecko.
  */
 
-import { ethers } from "ethers";
+import { ethers } from 'ethers';
 
-import { executeSwap } from "./swap_tokens";
-import { Logger } from "../../src/helpers/loggerHelper";
-import { ABI } from "../../src/services/web3/abiService";
-import { coingeckoService } from "../../src/services/coingecko/coingeckoService";
+import { executeSwap } from './swap_tokens';
+import { Logger } from '../../src/helpers/loggerHelper';
+import { ABI } from '../../src/services/web3/abiService';
+import { coingeckoService } from '../../src/services/coingecko/coingeckoService';
 
 // Type definitions
 interface PoolConfig {
-    readonly rpc: string;
-    readonly privateKey: string;
-    readonly usdtAddress: string;
-    readonly wethAddress: string;
-    readonly poolFee: number;
-    readonly swapRouterAddress: string;
-    readonly factoryAddress: string;
-    readonly gasLimit: number;
+  readonly rpc: string;
+  readonly privateKey: string;
+  readonly usdtAddress: string;
+  readonly wethAddress: string;
+  readonly poolFee: number;
+  readonly swapRouterAddress: string;
+  readonly factoryAddress: string;
+  readonly gasLimit: number;
 }
 
 interface TokenBalances {
-    readonly poolBalanceA: ethers.BigNumber;
-    readonly poolBalanceB: ethers.BigNumber;
-    readonly tokenADecimals: number;
-    readonly tokenBDecimals: number;
+  readonly poolBalanceA: ethers.BigNumber;
+  readonly poolBalanceB: ethers.BigNumber;
+  readonly tokenADecimals: number;
+  readonly tokenBDecimals: number;
 }
 
 /**
@@ -35,44 +35,44 @@ interface TokenBalances {
  * Network: Arbitrum Sepolia
  */
 const getConfig = (): PoolConfig => {
-    const requiredEnvVars = [
-        'SIGNING_KEY'
-    ];
+  const requiredEnvVars = ['SIGNING_KEY'];
 
-    requiredEnvVars.forEach(envVar => {
-        if (!process.env[envVar]) {
-            throw new Error(`Missing required environment variable: ${envVar}`);
-        }
-    });
+  requiredEnvVars.forEach((envVar) => {
+    if (!process.env[envVar]) {
+      throw new Error(`Missing required environment variable: ${envVar}`);
+    }
+  });
 
-    return {
-        rpc: `https://arb-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY ?? ''}`,
-        privateKey: process.env.SIGNING_KEY!,
-        usdtAddress: process.env.USDT_ADDRESS ?? '0xe6B817E31421929403040c3e42A6a5C5D2958b4A',
-        wethAddress: process.env.WETH_ADDRESS ?? '0xe9c723d01393a437bac13ce8f925a5bc8e1c335c',
-        poolFee: 3000, // 0.3%
-        swapRouterAddress: process.env.SWAP_ROUTER_ADDRESS ?? '0x101F443B4d1b059569D643917553c771E1b9663E',
-        factoryAddress: process.env.UNISWAP_FACTORY_ADDRESS ?? '0x248AB79Bbb9bC29bB72f7Cd42F17e054Fc40188e',
-        gasLimit: 3000000,
-    };
+  return {
+    rpc: `https://arb-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY ?? ''}`,
+    privateKey: process.env.SIGNING_KEY!,
+    usdtAddress: process.env.USDT_ADDRESS ?? '0xe6B817E31421929403040c3e42A6a5C5D2958b4A',
+    wethAddress: process.env.WETH_ADDRESS ?? '0xe9c723d01393a437bac13ce8f925a5bc8e1c335c',
+    poolFee: 3000, // 0.3%
+    swapRouterAddress:
+      process.env.SWAP_ROUTER_ADDRESS ?? '0x101F443B4d1b059569D643917553c771E1b9663E',
+    factoryAddress:
+      process.env.UNISWAP_FACTORY_ADDRESS ?? '0x248AB79Bbb9bC29bB72f7Cd42F17e054Fc40188e',
+    gasLimit: 3000000
+  };
 };
 
 /**
  * Minimal ERC20 ABI for required operations
  */
 const ERC20_ABI: ABI = [
-    'function balanceOf(address owner) view returns (uint256)',
-    'function decimals() view returns (uint8)',
-    'function mint(address to, uint256 amount) returns (bool)',
-    'function approve(address spender, uint256 amount) returns (bool)',
-    'function allowance(address owner, address spender) view returns (uint256)'
+  'function balanceOf(address owner) view returns (uint256)',
+  'function decimals() view returns (uint8)',
+  'function mint(address to, uint256 amount) returns (bool)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+  'function allowance(address owner, address spender) view returns (uint256)'
 ];
 
 /**
  * Minimal Factory ABI for pool retrieval
  */
 const FACTORY_ABI: ABI = [
-    'function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool)'
+  'function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool)'
 ];
 
 /**
@@ -80,50 +80,50 @@ const FACTORY_ABI: ABI = [
  * to make the resulting pool price (token0/token1) equal to targetPrice.
  *
  * Based on the AMM invariant: k = reserve0 * reserve1
- * 
+ *
  * After the swap:
  *   - reserve0' = reserve0 + Δtoken0
  *   - reserve1' = reserve1 - Δtoken1
- * 
+ *
  * And we want:
  *   (reserve0 + Δtoken0) / (reserve1 - Δtoken1) = targetPrice
- * 
+ *
  * Solving using the invariant:
  *   newReserve1 = sqrt((reserve0 * reserve1) / targetPrice)
  *   newReserve0 = targetPrice * newReserve1 = sqrt(targetPrice * reserve0 * reserve1)
- * 
+ *
  * The amount of token0 to swap is:
  *   Δtoken0 = newReserve0 - reserve0
- * 
+ *
  * @param reserve0 - Current amount of token0 in the pool
  * @param reserve1 - Current amount of token1 in the pool
  * @param targetPrice - Desired price (token0 per 1 token1)
  * @returns The amount of token0 to swap
  */
 const calculateSwapForTargetPrice = (
-    reserve0: ethers.BigNumber,
-    reserve1: ethers.BigNumber,
-    targetPrice: number
+  reserve0: ethers.BigNumber,
+  reserve1: ethers.BigNumber,
+  targetPrice: number
 ): number => {
-    // Convert BigNumbers to numeric values for mathematical calculations
-    const reserve0Num = parseFloat(ethers.utils.formatUnits(reserve0, 18));
-    const reserve1Num = parseFloat(ethers.utils.formatUnits(reserve1, 18));
+  // Convert BigNumbers to numeric values for mathematical calculations
+  const reserve0Num = parseFloat(ethers.utils.formatUnits(reserve0, 18));
+  const reserve1Num = parseFloat(ethers.utils.formatUnits(reserve1, 18));
 
-    const k = reserve0Num * reserve1Num;
+  const k = reserve0Num * reserve1Num;
 
-    // New reserve of token1 to achieve the target price
-    const newReserve1 = Math.sqrt(k / targetPrice);
+  // New reserve of token1 to achieve the target price
+  const newReserve1 = Math.sqrt(k / targetPrice);
 
-    // New reserve of token0 (since price is targetPrice = newReserve0/newReserve1)
-    const newReserve0 = targetPrice * newReserve1;
+  // New reserve of token0 (since price is targetPrice = newReserve0/newReserve1)
+  const newReserve0 = targetPrice * newReserve1;
 
-    // Token0 amount to swap
-    return newReserve0 - reserve0Num;
+  // Token0 amount to swap
+  return newReserve0 - reserve0Num;
 };
 
 /**
  * Retrieves the Uniswap V3 pool address for a token pair.
- * 
+ *
  * @param tokenA - Token A address
  * @param tokenB - Token B address
  * @param config - Pool configuration
@@ -132,31 +132,35 @@ const calculateSwapForTargetPrice = (
  * @throws Error if the pool doesn't exist
  */
 const getPoolAddress = async (
-    tokenA: string,
-    tokenB: string,
-    config: PoolConfig,
-    provider: ethers.providers.JsonRpcProvider
+  tokenA: string,
+  tokenB: string,
+  config: PoolConfig,
+  provider: ethers.providers.JsonRpcProvider
 ): Promise<string> => {
-    try {
-        const factory = new ethers.Contract(config.factoryAddress, FACTORY_ABI, provider);
+  try {
+    const factory = new ethers.Contract(config.factoryAddress, FACTORY_ABI, provider);
 
-        // Get pool with the configured fee tier
-        const poolAddress = await factory.getPool(tokenA, tokenB, config.poolFee);
+    // Get pool with the configured fee tier
+    const poolAddress = await factory.getPool(tokenA, tokenB, config.poolFee);
 
-        if (poolAddress === ethers.constants.AddressZero) {
-            throw new Error(`Pool not found for tokens ${tokenA} and ${tokenB} with fee ${config.poolFee}`);
-        }
-
-        return poolAddress;
-    } catch (error) {
-        Logger.error(`Error retrieving pool address: ${error instanceof Error ? error.message : String(error)}`);
-        throw error;
+    if (poolAddress === ethers.constants.AddressZero) {
+      throw new Error(
+        `Pool not found for tokens ${tokenA} and ${tokenB} with fee ${config.poolFee}`
+      );
     }
+
+    return poolAddress;
+  } catch (error) {
+    Logger.error(
+      `Error retrieving pool address: ${error instanceof Error ? error.message : String(error)}`
+    );
+    throw error;
+  }
 };
 
 /**
  * Gets the token balances in a Uniswap pool.
- * 
+ *
  * @param tokenA - Token A address
  * @param tokenB - Token B address
  * @param config - Pool configuration
@@ -164,41 +168,43 @@ const getPoolAddress = async (
  * @returns Object with token balances and decimals
  */
 const getPoolBalances = async (
-    tokenA: string,
-    tokenB: string,
-    config: PoolConfig,
-    provider: ethers.providers.JsonRpcProvider
+  tokenA: string,
+  tokenB: string,
+  config: PoolConfig,
+  provider: ethers.providers.JsonRpcProvider
 ): Promise<TokenBalances> => {
-    try {
-        const poolAddress = await getPoolAddress(tokenA, tokenB, config, provider);
+  try {
+    const poolAddress = await getPoolAddress(tokenA, tokenB, config, provider);
 
-        const tokenAContract = new ethers.Contract(tokenA, ERC20_ABI, provider);
-        const tokenBContract = new ethers.Contract(tokenB, ERC20_ABI, provider);
+    const tokenAContract = new ethers.Contract(tokenA, ERC20_ABI, provider);
+    const tokenBContract = new ethers.Contract(tokenB, ERC20_ABI, provider);
 
-        // Run all queries in parallel for optimization
-        const [poolBalanceA, tokenADecimals, poolBalanceB, tokenBDecimals] = await Promise.all([
-            tokenAContract.balanceOf(poolAddress),
-            tokenAContract.decimals(),
-            tokenBContract.balanceOf(poolAddress),
-            tokenBContract.decimals()
-        ]);
+    // Run all queries in parallel for optimization
+    const [poolBalanceA, tokenADecimals, poolBalanceB, tokenBDecimals] = await Promise.all([
+      tokenAContract.balanceOf(poolAddress),
+      tokenAContract.decimals(),
+      tokenBContract.balanceOf(poolAddress),
+      tokenBContract.decimals()
+    ]);
 
-        return {
-            poolBalanceA,
-            poolBalanceB,
-            tokenADecimals,
-            tokenBDecimals
-        };
-    } catch (error) {
-        Logger.error(`Error getting pool balances: ${error instanceof Error ? error.message : String(error)}`);
-        throw error;
-    }
+    return {
+      poolBalanceA,
+      poolBalanceB,
+      tokenADecimals,
+      tokenBDecimals
+    };
+  } catch (error) {
+    Logger.error(
+      `Error getting pool balances: ${error instanceof Error ? error.message : String(error)}`
+    );
+    throw error;
+  }
 };
 
 /**
  * Ensures the signer has sufficient balance for the swap.
  * If insufficient, mints more tokens with a 20% safety margin.
- * 
+ *
  * @param tokenAddress - Token address
  * @param amount - Required amount
  * @param signer - Transaction signer
@@ -206,163 +212,160 @@ const getPoolBalances = async (
  * @returns true if balance is ensured
  */
 const ensureTokenBalance = async (
-    tokenAddress: string,
-    amount: ethers.BigNumber,
-    signer: ethers.Signer,
-    routerAddress: string
+  tokenAddress: string,
+  amount: ethers.BigNumber,
+  signer: ethers.Signer,
+  routerAddress: string
 ): Promise<boolean> => {
-    try {
-        const signerAddress = await signer.getAddress();
-        const token = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
+  try {
+    const signerAddress = await signer.getAddress();
+    const token = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
 
-        // Check current balance
-        const balance = await token.balanceOf(signerAddress);
-        const tokenDecimals = await token.decimals();
+    // Check current balance
+    const balance = await token.balanceOf(signerAddress);
+    const tokenDecimals = await token.decimals();
 
-        if (balance.lt(amount)) {
-            // Calculate 20% extra for safety margin
-            const mintAmount = amount.mul(120).div(100);
+    if (balance.lt(amount)) {
+      // Calculate 20% extra for safety margin
+      const mintAmount = amount.mul(120).div(100);
 
-            Logger.info(`Insufficient balance. Minting ${ethers.utils.formatUnits(mintAmount, tokenDecimals)} tokens...`);
+      Logger.info(
+        `Insufficient balance. Minting ${ethers.utils.formatUnits(mintAmount, tokenDecimals)} tokens...`
+      );
 
-            const mintTx = await token.mint(signerAddress, mintAmount);
-            await mintTx.wait();
+      const mintTx = await token.mint(signerAddress, mintAmount);
+      await mintTx.wait();
 
-            Logger.info(`Tokens successfully minted`);
-        }
-
-        // Check allowance
-        const allowance = await token.allowance(signerAddress, routerAddress);
-
-        if (allowance.lt(amount)) {
-            Logger.info(`Approving ${ethers.utils.formatUnits(amount, tokenDecimals)} tokens for router...`);
-
-            const approveTx = await token.approve(routerAddress, ethers.constants.MaxUint256);
-            await approveTx.wait();
-
-            Logger.info(`Tokens successfully approved`);
-        }
-
-        return true;
-    } catch (error) {
-        Logger.error(`Error ensuring token balance: ${error instanceof Error ? error.message : String(error)}`);
-        throw error;
+      Logger.info(`Tokens successfully minted`);
     }
+
+    // Check allowance
+    const allowance = await token.allowance(signerAddress, routerAddress);
+
+    if (allowance.lt(amount)) {
+      Logger.info(
+        `Approving ${ethers.utils.formatUnits(amount, tokenDecimals)} tokens for router...`
+      );
+
+      const approveTx = await token.approve(routerAddress, ethers.constants.MaxUint256);
+      await approveTx.wait();
+
+      Logger.info(`Tokens successfully approved`);
+    }
+
+    return true;
+  } catch (error) {
+    Logger.error(
+      `Error ensuring token balance: ${error instanceof Error ? error.message : String(error)}`
+    );
+    throw error;
+  }
 };
 
 /**
  * Prepares tokens for swapping by ensuring balances and approvals.
- * 
+ *
  * @param signer - Transaction signer
  * @param tokenAddress - Token address to swap
  * @param amount - Amount to swap
  * @param config - Pool configuration
  */
 const prepareForSwap = async (
-    signer: ethers.Wallet,
-    tokenAddress: string,
-    amount: ethers.BigNumber,
-    config: PoolConfig
+  signer: ethers.Wallet,
+  tokenAddress: string,
+  amount: ethers.BigNumber,
+  config: PoolConfig
 ): Promise<void> => {
-    await ensureTokenBalance(
-        tokenAddress,
-        amount,
-        signer,
-        config.swapRouterAddress
-    );
+  await ensureTokenBalance(tokenAddress, amount, signer, config.swapRouterAddress);
 };
 
 /**
  * Converts a number to BigNumber handling scientific notation correctly.
- * 
+ *
  * @param amount - Numeric amount
  * @param decimals - Token decimals
  * @returns Equivalent BigNumber
  */
 const toBigNumber = (amount: number, decimals: number): ethers.BigNumber => {
-    // Convert scientific notation to regular string
-    const amountStr = amount.toLocaleString('fullwide', { useGrouping: false });
+  // Convert scientific notation to regular string
+  const amountStr = amount.toLocaleString('fullwide', { useGrouping: false });
 
-    // Determine if the number is an integer or has decimals
-    if (!amountStr.includes('.')) {
-        return ethers.utils.parseUnits(amountStr, decimals);
-    }
+  // Determine if the number is an integer or has decimals
+  if (!amountStr.includes('.')) {
+    return ethers.utils.parseUnits(amountStr, decimals);
+  }
 
-    // Handle numbers with decimals
-    const [integerPart, decimalPart] = amountStr.split('.');
-    const paddedDecimalPart = decimalPart.padEnd(decimals, '0').slice(0, decimals);
+  // Handle numbers with decimals
+  const [integerPart, decimalPart] = amountStr.split('.');
+  const paddedDecimalPart = decimalPart.padEnd(decimals, '0').slice(0, decimals);
 
-    return ethers.BigNumber.from(integerPart + paddedDecimalPart);
+  return ethers.BigNumber.from(integerPart + paddedDecimalPart);
 };
 
 /**
  * Main function that executes the pool adjustment logic.
  */
 async function main() {
-    try {
-        Logger.info('Starting pool adjustment script...');
+  try {
+    Logger.info('Starting pool adjustment script...');
 
-        // Get configuration
-        const config = getConfig();
+    // Get configuration
+    const config = getConfig();
 
-        // Get target price from Coingecko
-        const targetPrice = await coingeckoService.getTokenPrice('ethereum');
-        Logger.info(`Target price: ${targetPrice} USDT per ETH`);
+    // Get target price from Coingecko
+    const targetPrice = await coingeckoService.getTokenPrice('ethereum');
+    Logger.info(`Target price: ${targetPrice} USDT per ETH`);
 
-        // Initialize provider and wallet
-        const provider = new ethers.providers.JsonRpcProvider(config.rpc);
-        const wallet = new ethers.Wallet(config.privateKey, provider);
+    // Initialize provider and wallet
+    const provider = new ethers.providers.JsonRpcProvider(config.rpc);
+    const wallet = new ethers.Wallet(config.privateKey, provider);
 
-        // Get pool balances
-        const { poolBalanceA, poolBalanceB, tokenADecimals } = await getPoolBalances(
-            config.usdtAddress,
-            config.wethAddress,
-            config,
-            provider
-        );
+    // Get pool balances
+    const { poolBalanceA, poolBalanceB, tokenADecimals } = await getPoolBalances(
+      config.usdtAddress,
+      config.wethAddress,
+      config,
+      provider
+    );
 
-        // Calculate amount to swap to reach target price
-        const tokensToSwap = calculateSwapForTargetPrice(
-            poolBalanceA,
-            poolBalanceB,
-            targetPrice
-        );
+    // Calculate amount to swap to reach target price
+    const tokensToSwap = calculateSwapForTargetPrice(poolBalanceA, poolBalanceB, targetPrice);
 
-        // Validate if amount is significant
-        if (tokensToSwap < 1) {
-            Logger.info('Amount to swap is too small to rebalance...');
-            return;
-        }
-
-        // Convert to BigNumber for transactions
-        const depositTokenABN = toBigNumber(tokensToSwap, tokenADecimals);
-        const depositTokenAFormatted = ethers.utils.formatUnits(depositTokenABN, tokenADecimals);
-
-        Logger.info(`Swapping ${depositTokenAFormatted} USDT for WETH to adjust pool price...`);
-
-        // Prepare tokens for swap
-        await prepareForSwap(wallet, config.usdtAddress, depositTokenABN, config);
-
-        // Execute swap
-        await executeSwap({
-            config,
-            amountIn: depositTokenAFormatted,
-            tokenIn: config.usdtAddress,
-            tokenOut: config.wethAddress
-        });
-
-        Logger.info('Swap completed successfully.');
-    } catch (error) {
-        Logger.error(`Execution error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
+    // Validate if amount is significant
+    if (tokensToSwap < 1) {
+      Logger.info('Amount to swap is too small to rebalance...');
+      return;
     }
+
+    // Convert to BigNumber for transactions
+    const depositTokenABN = toBigNumber(tokensToSwap, tokenADecimals);
+    const depositTokenAFormatted = ethers.utils.formatUnits(depositTokenABN, tokenADecimals);
+
+    Logger.info(`Swapping ${depositTokenAFormatted} USDT for WETH to adjust pool price...`);
+
+    // Prepare tokens for swap
+    await prepareForSwap(wallet, config.usdtAddress, depositTokenABN, config);
+
+    // Execute swap
+    await executeSwap({
+      config,
+      amountIn: depositTokenAFormatted,
+      tokenIn: config.usdtAddress,
+      tokenOut: config.wethAddress
+    });
+
+    Logger.info('Swap completed successfully.');
+  } catch (error) {
+    Logger.error(`Execution error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
 }
 
 main()
-    .then(() => process.exit(0))
-    .catch((error) => {
-        Logger.error(`Fatal error: ${error instanceof Error ? error.message : String(error)}`);
-        process.exit(1);
-    });
+  .then(() => process.exit(0))
+  .catch((error) => {
+    Logger.error(`Fatal error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  });
 
 export { executeSwap };

--- a/scripts/swap_debug/adjust_pool.ts
+++ b/scripts/swap_debug/adjust_pool.ts
@@ -1,0 +1,368 @@
+/**
+ * @file adjust_pool.ts
+ * @description Adjusts a Uniswap pool price in testnet to target a specific value,
+ * currently based on Ethereum's price from Coingecko.
+ */
+
+import { ethers } from "ethers";
+
+import { executeSwap } from "./swap_tokens";
+import { Logger } from "../../src/helpers/loggerHelper";
+import { ABI } from "../../src/services/web3/abiService";
+import { coingeckoService } from "../../src/services/coingecko/coingeckoService";
+
+// Type definitions
+interface PoolConfig {
+    readonly rpc: string;
+    readonly privateKey: string;
+    readonly usdtAddress: string;
+    readonly wethAddress: string;
+    readonly poolFee: number;
+    readonly swapRouterAddress: string;
+    readonly factoryAddress: string;
+    readonly gasLimit: number;
+}
+
+interface TokenBalances {
+    readonly poolBalanceA: ethers.BigNumber;
+    readonly poolBalanceB: ethers.BigNumber;
+    readonly tokenADecimals: number;
+    readonly tokenBDecimals: number;
+}
+
+/**
+ * Environment configuration setup
+ * Network: Arbitrum Sepolia
+ */
+const getConfig = (): PoolConfig => {
+    const requiredEnvVars = [
+        'SIGNING_KEY'
+    ];
+
+    requiredEnvVars.forEach(envVar => {
+        if (!process.env[envVar]) {
+            throw new Error(`Missing required environment variable: ${envVar}`);
+        }
+    });
+
+    return {
+        rpc: `https://arb-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY ?? ''}`,
+        privateKey: process.env.SIGNING_KEY!,
+        usdtAddress: process.env.USDT_ADDRESS ?? '0xe6B817E31421929403040c3e42A6a5C5D2958b4A',
+        wethAddress: process.env.WETH_ADDRESS ?? '0xe9c723d01393a437bac13ce8f925a5bc8e1c335c',
+        poolFee: 3000, // 0.3%
+        swapRouterAddress: process.env.SWAP_ROUTER_ADDRESS ?? '0x101F443B4d1b059569D643917553c771E1b9663E',
+        factoryAddress: process.env.UNISWAP_FACTORY_ADDRESS ?? '0x248AB79Bbb9bC29bB72f7Cd42F17e054Fc40188e',
+        gasLimit: 3000000,
+    };
+};
+
+/**
+ * Minimal ERC20 ABI for required operations
+ */
+const ERC20_ABI: ABI = [
+    'function balanceOf(address owner) view returns (uint256)',
+    'function decimals() view returns (uint8)',
+    'function mint(address to, uint256 amount) returns (bool)',
+    'function approve(address spender, uint256 amount) returns (bool)',
+    'function allowance(address owner, address spender) view returns (uint256)'
+];
+
+/**
+ * Minimal Factory ABI for pool retrieval
+ */
+const FACTORY_ABI: ABI = [
+    'function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool)'
+];
+
+/**
+ * Calculates how many token0 tokens should be swapped for token1 in a single transaction
+ * to make the resulting pool price (token0/token1) equal to targetPrice.
+ *
+ * Based on the AMM invariant: k = reserve0 * reserve1
+ * 
+ * After the swap:
+ *   - reserve0' = reserve0 + Δtoken0
+ *   - reserve1' = reserve1 - Δtoken1
+ * 
+ * And we want:
+ *   (reserve0 + Δtoken0) / (reserve1 - Δtoken1) = targetPrice
+ * 
+ * Solving using the invariant:
+ *   newReserve1 = sqrt((reserve0 * reserve1) / targetPrice)
+ *   newReserve0 = targetPrice * newReserve1 = sqrt(targetPrice * reserve0 * reserve1)
+ * 
+ * The amount of token0 to swap is:
+ *   Δtoken0 = newReserve0 - reserve0
+ * 
+ * @param reserve0 - Current amount of token0 in the pool
+ * @param reserve1 - Current amount of token1 in the pool
+ * @param targetPrice - Desired price (token0 per 1 token1)
+ * @returns The amount of token0 to swap
+ */
+const calculateSwapForTargetPrice = (
+    reserve0: ethers.BigNumber,
+    reserve1: ethers.BigNumber,
+    targetPrice: number
+): number => {
+    // Convert BigNumbers to numeric values for mathematical calculations
+    const reserve0Num = parseFloat(ethers.utils.formatUnits(reserve0, 18));
+    const reserve1Num = parseFloat(ethers.utils.formatUnits(reserve1, 18));
+
+    const k = reserve0Num * reserve1Num;
+
+    // New reserve of token1 to achieve the target price
+    const newReserve1 = Math.sqrt(k / targetPrice);
+
+    // New reserve of token0 (since price is targetPrice = newReserve0/newReserve1)
+    const newReserve0 = targetPrice * newReserve1;
+
+    // Token0 amount to swap
+    return newReserve0 - reserve0Num;
+};
+
+/**
+ * Retrieves the Uniswap V3 pool address for a token pair.
+ * 
+ * @param tokenA - Token A address
+ * @param tokenB - Token B address
+ * @param config - Pool configuration
+ * @param provider - Ethereum provider
+ * @returns Uniswap V3 pool address
+ * @throws Error if the pool doesn't exist
+ */
+const getPoolAddress = async (
+    tokenA: string,
+    tokenB: string,
+    config: PoolConfig,
+    provider: ethers.providers.JsonRpcProvider
+): Promise<string> => {
+    try {
+        const factory = new ethers.Contract(config.factoryAddress, FACTORY_ABI, provider);
+
+        // Get pool with the configured fee tier
+        const poolAddress = await factory.getPool(tokenA, tokenB, config.poolFee);
+
+        if (poolAddress === ethers.constants.AddressZero) {
+            throw new Error(`Pool not found for tokens ${tokenA} and ${tokenB} with fee ${config.poolFee}`);
+        }
+
+        return poolAddress;
+    } catch (error) {
+        Logger.error(`Error retrieving pool address: ${error instanceof Error ? error.message : String(error)}`);
+        throw error;
+    }
+};
+
+/**
+ * Gets the token balances in a Uniswap pool.
+ * 
+ * @param tokenA - Token A address
+ * @param tokenB - Token B address
+ * @param config - Pool configuration
+ * @param provider - Ethereum provider
+ * @returns Object with token balances and decimals
+ */
+const getPoolBalances = async (
+    tokenA: string,
+    tokenB: string,
+    config: PoolConfig,
+    provider: ethers.providers.JsonRpcProvider
+): Promise<TokenBalances> => {
+    try {
+        const poolAddress = await getPoolAddress(tokenA, tokenB, config, provider);
+
+        const tokenAContract = new ethers.Contract(tokenA, ERC20_ABI, provider);
+        const tokenBContract = new ethers.Contract(tokenB, ERC20_ABI, provider);
+
+        // Run all queries in parallel for optimization
+        const [poolBalanceA, tokenADecimals, poolBalanceB, tokenBDecimals] = await Promise.all([
+            tokenAContract.balanceOf(poolAddress),
+            tokenAContract.decimals(),
+            tokenBContract.balanceOf(poolAddress),
+            tokenBContract.decimals()
+        ]);
+
+        return {
+            poolBalanceA,
+            poolBalanceB,
+            tokenADecimals,
+            tokenBDecimals
+        };
+    } catch (error) {
+        Logger.error(`Error getting pool balances: ${error instanceof Error ? error.message : String(error)}`);
+        throw error;
+    }
+};
+
+/**
+ * Ensures the signer has sufficient balance for the swap.
+ * If insufficient, mints more tokens with a 20% safety margin.
+ * 
+ * @param tokenAddress - Token address
+ * @param amount - Required amount
+ * @param signer - Transaction signer
+ * @param routerAddress - Uniswap router address
+ * @returns true if balance is ensured
+ */
+const ensureTokenBalance = async (
+    tokenAddress: string,
+    amount: ethers.BigNumber,
+    signer: ethers.Signer,
+    routerAddress: string
+): Promise<boolean> => {
+    try {
+        const signerAddress = await signer.getAddress();
+        const token = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
+
+        // Check current balance
+        const balance = await token.balanceOf(signerAddress);
+        const tokenDecimals = await token.decimals();
+
+        if (balance.lt(amount)) {
+            // Calculate 20% extra for safety margin
+            const mintAmount = amount.mul(120).div(100);
+
+            Logger.info(`Insufficient balance. Minting ${ethers.utils.formatUnits(mintAmount, tokenDecimals)} tokens...`);
+
+            const mintTx = await token.mint(signerAddress, mintAmount);
+            await mintTx.wait();
+
+            Logger.info(`Tokens successfully minted`);
+        }
+
+        // Check allowance
+        const allowance = await token.allowance(signerAddress, routerAddress);
+
+        if (allowance.lt(amount)) {
+            Logger.info(`Approving ${ethers.utils.formatUnits(amount, tokenDecimals)} tokens for router...`);
+
+            const approveTx = await token.approve(routerAddress, ethers.constants.MaxUint256);
+            await approveTx.wait();
+
+            Logger.info(`Tokens successfully approved`);
+        }
+
+        return true;
+    } catch (error) {
+        Logger.error(`Error ensuring token balance: ${error instanceof Error ? error.message : String(error)}`);
+        throw error;
+    }
+};
+
+/**
+ * Prepares tokens for swapping by ensuring balances and approvals.
+ * 
+ * @param signer - Transaction signer
+ * @param tokenAddress - Token address to swap
+ * @param amount - Amount to swap
+ * @param config - Pool configuration
+ */
+const prepareForSwap = async (
+    signer: ethers.Wallet,
+    tokenAddress: string,
+    amount: ethers.BigNumber,
+    config: PoolConfig
+): Promise<void> => {
+    await ensureTokenBalance(
+        tokenAddress,
+        amount,
+        signer,
+        config.swapRouterAddress
+    );
+};
+
+/**
+ * Converts a number to BigNumber handling scientific notation correctly.
+ * 
+ * @param amount - Numeric amount
+ * @param decimals - Token decimals
+ * @returns Equivalent BigNumber
+ */
+const toBigNumber = (amount: number, decimals: number): ethers.BigNumber => {
+    // Convert scientific notation to regular string
+    const amountStr = amount.toLocaleString('fullwide', { useGrouping: false });
+
+    // Determine if the number is an integer or has decimals
+    if (!amountStr.includes('.')) {
+        return ethers.utils.parseUnits(amountStr, decimals);
+    }
+
+    // Handle numbers with decimals
+    const [integerPart, decimalPart] = amountStr.split('.');
+    const paddedDecimalPart = decimalPart.padEnd(decimals, '0').slice(0, decimals);
+
+    return ethers.BigNumber.from(integerPart + paddedDecimalPart);
+};
+
+/**
+ * Main function that executes the pool adjustment logic.
+ */
+async function main() {
+    try {
+        Logger.info('Starting pool adjustment script...');
+
+        // Get configuration
+        const config = getConfig();
+
+        // Get target price from Coingecko
+        const targetPrice = await coingeckoService.getTokenPrice('ethereum');
+        Logger.info(`Target price: ${targetPrice} USDT per ETH`);
+
+        // Initialize provider and wallet
+        const provider = new ethers.providers.JsonRpcProvider(config.rpc);
+        const wallet = new ethers.Wallet(config.privateKey, provider);
+
+        // Get pool balances
+        const { poolBalanceA, poolBalanceB, tokenADecimals } = await getPoolBalances(
+            config.usdtAddress,
+            config.wethAddress,
+            config,
+            provider
+        );
+
+        // Calculate amount to swap to reach target price
+        const tokensToSwap = calculateSwapForTargetPrice(
+            poolBalanceA,
+            poolBalanceB,
+            targetPrice
+        );
+
+        // Validate if amount is significant
+        if (tokensToSwap < 1) {
+            Logger.info('Amount to swap is too small to rebalance...');
+            return;
+        }
+
+        // Convert to BigNumber for transactions
+        const depositTokenABN = toBigNumber(tokensToSwap, tokenADecimals);
+        const depositTokenAFormatted = ethers.utils.formatUnits(depositTokenABN, tokenADecimals);
+
+        Logger.info(`Swapping ${depositTokenAFormatted} USDT for WETH to adjust pool price...`);
+
+        // Prepare tokens for swap
+        await prepareForSwap(wallet, config.usdtAddress, depositTokenABN, config);
+
+        // Execute swap
+        await executeSwap({
+            config,
+            amountIn: depositTokenAFormatted,
+            tokenIn: config.usdtAddress,
+            tokenOut: config.wethAddress
+        });
+
+        Logger.info('Swap completed successfully.');
+    } catch (error) {
+        Logger.error(`Execution error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+    }
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        Logger.error(`Fatal error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+    });
+
+export { executeSwap };

--- a/scripts/swap_debug/adjust_pool.ts
+++ b/scripts/swap_debug/adjust_pool.ts
@@ -1,7 +1,8 @@
 /**
  * @file adjust_pool.ts
  * @description Adjusts a Uniswap pool price in testnet to target a specific value,
- * currently based on Ethereum's price from Coingecko.
+ * currently based on Ethereum's price from Coingecko. Supports bidirectional adjustments
+ * (buying or selling) depending on the current pool price.
  */
 
 import { ethers } from 'ethers';
@@ -13,21 +14,21 @@ import { coingeckoService } from '../../src/services/coingecko/coingeckoService'
 
 // Type definitions
 interface PoolConfig {
-  readonly rpc: string;
-  readonly privateKey: string;
-  readonly usdtAddress: string;
-  readonly wethAddress: string;
-  readonly poolFee: number;
-  readonly swapRouterAddress: string;
-  readonly factoryAddress: string;
-  readonly gasLimit: number;
+    readonly rpc: string;
+    readonly privateKey: string;
+    readonly usdtAddress: string;
+    readonly wethAddress: string;
+    readonly poolFee: number;
+    readonly swapRouterAddress: string;
+    readonly factoryAddress: string;
+    readonly gasLimit: number;
 }
 
 interface TokenBalances {
-  readonly poolBalanceA: ethers.BigNumber;
-  readonly poolBalanceB: ethers.BigNumber;
-  readonly tokenADecimals: number;
-  readonly tokenBDecimals: number;
+    readonly poolBalanceA: ethers.BigNumber;
+    readonly poolBalanceB: ethers.BigNumber;
+    readonly tokenADecimals: number;
+    readonly tokenBDecimals: number;
 }
 
 /**
@@ -35,44 +36,44 @@ interface TokenBalances {
  * Network: Arbitrum Sepolia
  */
 const getConfig = (): PoolConfig => {
-  const requiredEnvVars = ['SIGNING_KEY'];
+    const requiredEnvVars = ['SIGNING_KEY'];
 
-  requiredEnvVars.forEach((envVar) => {
-    if (!process.env[envVar]) {
-      throw new Error(`Missing required environment variable: ${envVar}`);
-    }
-  });
+    requiredEnvVars.forEach((envVar) => {
+        if (!process.env[envVar]) {
+            throw new Error(`Missing required environment variable: ${envVar}`);
+        }
+    });
 
-  return {
-    rpc: `https://arb-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY ?? ''}`,
-    privateKey: process.env.SIGNING_KEY!,
-    usdtAddress: process.env.USDT_ADDRESS ?? '0xe6B817E31421929403040c3e42A6a5C5D2958b4A',
-    wethAddress: process.env.WETH_ADDRESS ?? '0xe9c723d01393a437bac13ce8f925a5bc8e1c335c',
-    poolFee: 3000, // 0.3%
-    swapRouterAddress:
-      process.env.SWAP_ROUTER_ADDRESS ?? '0x101F443B4d1b059569D643917553c771E1b9663E',
-    factoryAddress:
-      process.env.UNISWAP_FACTORY_ADDRESS ?? '0x248AB79Bbb9bC29bB72f7Cd42F17e054Fc40188e',
-    gasLimit: 3000000
-  };
+    return {
+        rpc: `https://arb-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY ?? ''}`,
+        privateKey: process.env.SIGNING_KEY!,
+        usdtAddress: process.env.USDT_ADDRESS ?? '0xe6B817E31421929403040c3e42A6a5C5D2958b4A',
+        wethAddress: process.env.WETH_ADDRESS ?? '0xe9c723d01393a437bac13ce8f925a5bc8e1c335c',
+        poolFee: 3000, // 0.3%
+        swapRouterAddress:
+            process.env.SWAP_ROUTER_ADDRESS ?? '0x101F443B4d1b059569D643917553c771E1b9663E',
+        factoryAddress:
+            process.env.UNISWAP_FACTORY_ADDRESS ?? '0x248AB79Bbb9bC29bB72f7Cd42F17e054Fc40188e',
+        gasLimit: 3000000
+    };
 };
 
 /**
  * Minimal ERC20 ABI for required operations
  */
 const ERC20_ABI: ABI = [
-  'function balanceOf(address owner) view returns (uint256)',
-  'function decimals() view returns (uint8)',
-  'function mint(address to, uint256 amount) returns (bool)',
-  'function approve(address spender, uint256 amount) returns (bool)',
-  'function allowance(address owner, address spender) view returns (uint256)'
+    'function balanceOf(address owner) view returns (uint256)',
+    'function decimals() view returns (uint8)',
+    'function mint(address to, uint256 amount) returns (bool)',
+    'function approve(address spender, uint256 amount) returns (bool)',
+    'function allowance(address owner, address spender) view returns (uint256)'
 ];
 
 /**
  * Minimal Factory ABI for pool retrieval
  */
 const FACTORY_ABI: ABI = [
-  'function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool)'
+    'function getPool(address tokenA, address tokenB, uint24 fee) external view returns (address pool)'
 ];
 
 /**
@@ -95,30 +96,34 @@ const FACTORY_ABI: ABI = [
  * The amount of token0 to swap is:
  *   Δtoken0 = newReserve0 - reserve0
  *
+ * Note: The returned value can be positive or negative:
+ *   - Positive: Need to add token0 to the pool (buy token0, sell token1)
+ *   - Negative: Need to remove token0 from the pool (sell token0, buy token1)
+ *
  * @param reserve0 - Current amount of token0 in the pool
  * @param reserve1 - Current amount of token1 in the pool
  * @param targetPrice - Desired price (token0 per 1 token1)
- * @returns The amount of token0 to swap
+ * @returns The amount of token0 to swap (signed value indicating direction)
  */
 const calculateSwapForTargetPrice = (
-  reserve0: ethers.BigNumber,
-  reserve1: ethers.BigNumber,
-  targetPrice: number
+    reserve0: ethers.BigNumber,
+    reserve1: ethers.BigNumber,
+    targetPrice: number
 ): number => {
-  // Convert BigNumbers to numeric values for mathematical calculations
-  const reserve0Num = parseFloat(ethers.utils.formatUnits(reserve0, 18));
-  const reserve1Num = parseFloat(ethers.utils.formatUnits(reserve1, 18));
+    // Convert BigNumbers to numeric values for mathematical calculations
+    const reserve0Num = parseFloat(ethers.utils.formatUnits(reserve0, 18));
+    const reserve1Num = parseFloat(ethers.utils.formatUnits(reserve1, 18));
 
-  const k = reserve0Num * reserve1Num;
+    const k = reserve0Num * reserve1Num;
 
-  // New reserve of token1 to achieve the target price
-  const newReserve1 = Math.sqrt(k / targetPrice);
+    // New reserve of token1 to achieve the target price
+    const newReserve1 = Math.sqrt(k / targetPrice);
 
-  // New reserve of token0 (since price is targetPrice = newReserve0/newReserve1)
-  const newReserve0 = targetPrice * newReserve1;
+    // New reserve of token0 (since price is targetPrice = newReserve0/newReserve1)
+    const newReserve0 = targetPrice * newReserve1;
 
-  // Token0 amount to swap
-  return newReserve0 - reserve0Num;
+    // Token0 amount to swap (can be positive or negative)
+    return newReserve0 - reserve0Num;
 };
 
 /**
@@ -132,30 +137,30 @@ const calculateSwapForTargetPrice = (
  * @throws Error if the pool doesn't exist
  */
 const getPoolAddress = async (
-  tokenA: string,
-  tokenB: string,
-  config: PoolConfig,
-  provider: ethers.providers.JsonRpcProvider
+    tokenA: string,
+    tokenB: string,
+    config: PoolConfig,
+    provider: ethers.providers.JsonRpcProvider
 ): Promise<string> => {
-  try {
-    const factory = new ethers.Contract(config.factoryAddress, FACTORY_ABI, provider);
+    try {
+        const factory = new ethers.Contract(config.factoryAddress, FACTORY_ABI, provider);
 
-    // Get pool with the configured fee tier
-    const poolAddress = await factory.getPool(tokenA, tokenB, config.poolFee);
+        // Get pool with the configured fee tier
+        const poolAddress = await factory.getPool(tokenA, tokenB, config.poolFee);
 
-    if (poolAddress === ethers.constants.AddressZero) {
-      throw new Error(
-        `Pool not found for tokens ${tokenA} and ${tokenB} with fee ${config.poolFee}`
-      );
+        if (poolAddress === ethers.constants.AddressZero) {
+            throw new Error(
+                `Pool not found for tokens ${tokenA} and ${tokenB} with fee ${config.poolFee}`
+            );
+        }
+
+        return poolAddress;
+    } catch (error) {
+        Logger.error(
+            `Error retrieving pool address: ${error instanceof Error ? error.message : String(error)}`
+        );
+        throw error;
     }
-
-    return poolAddress;
-  } catch (error) {
-    Logger.error(
-      `Error retrieving pool address: ${error instanceof Error ? error.message : String(error)}`
-    );
-    throw error;
-  }
 };
 
 /**
@@ -168,37 +173,37 @@ const getPoolAddress = async (
  * @returns Object with token balances and decimals
  */
 const getPoolBalances = async (
-  tokenA: string,
-  tokenB: string,
-  config: PoolConfig,
-  provider: ethers.providers.JsonRpcProvider
+    tokenA: string,
+    tokenB: string,
+    config: PoolConfig,
+    provider: ethers.providers.JsonRpcProvider
 ): Promise<TokenBalances> => {
-  try {
-    const poolAddress = await getPoolAddress(tokenA, tokenB, config, provider);
+    try {
+        const poolAddress = await getPoolAddress(tokenA, tokenB, config, provider);
 
-    const tokenAContract = new ethers.Contract(tokenA, ERC20_ABI, provider);
-    const tokenBContract = new ethers.Contract(tokenB, ERC20_ABI, provider);
+        const tokenAContract = new ethers.Contract(tokenA, ERC20_ABI, provider);
+        const tokenBContract = new ethers.Contract(tokenB, ERC20_ABI, provider);
 
-    // Run all queries in parallel for optimization
-    const [poolBalanceA, tokenADecimals, poolBalanceB, tokenBDecimals] = await Promise.all([
-      tokenAContract.balanceOf(poolAddress),
-      tokenAContract.decimals(),
-      tokenBContract.balanceOf(poolAddress),
-      tokenBContract.decimals()
-    ]);
+        // Run all queries in parallel for optimization
+        const [poolBalanceA, tokenADecimals, poolBalanceB, tokenBDecimals] = await Promise.all([
+            tokenAContract.balanceOf(poolAddress),
+            tokenAContract.decimals(),
+            tokenBContract.balanceOf(poolAddress),
+            tokenBContract.decimals()
+        ]);
 
-    return {
-      poolBalanceA,
-      poolBalanceB,
-      tokenADecimals,
-      tokenBDecimals
-    };
-  } catch (error) {
-    Logger.error(
-      `Error getting pool balances: ${error instanceof Error ? error.message : String(error)}`
-    );
-    throw error;
-  }
+        return {
+            poolBalanceA,
+            poolBalanceB,
+            tokenADecimals,
+            tokenBDecimals
+        };
+    } catch (error) {
+        Logger.error(
+            `Error getting pool balances: ${error instanceof Error ? error.message : String(error)}`
+        );
+        throw error;
+    }
 };
 
 /**
@@ -212,54 +217,54 @@ const getPoolBalances = async (
  * @returns true if balance is ensured
  */
 const ensureTokenBalance = async (
-  tokenAddress: string,
-  amount: ethers.BigNumber,
-  signer: ethers.Signer,
-  routerAddress: string
+    tokenAddress: string,
+    amount: ethers.BigNumber,
+    signer: ethers.Signer,
+    routerAddress: string
 ): Promise<boolean> => {
-  try {
-    const signerAddress = await signer.getAddress();
-    const token = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
+    try {
+        const signerAddress = await signer.getAddress();
+        const token = new ethers.Contract(tokenAddress, ERC20_ABI, signer);
 
-    // Check current balance
-    const balance = await token.balanceOf(signerAddress);
-    const tokenDecimals = await token.decimals();
+        // Check current balance
+        const balance = await token.balanceOf(signerAddress);
+        const tokenDecimals = await token.decimals();
 
-    if (balance.lt(amount)) {
-      // Calculate 20% extra for safety margin
-      const mintAmount = amount.mul(120).div(100);
+        if (balance.lt(amount)) {
+            // Calculate 20% extra for safety margin
+            const mintAmount = amount.mul(120).div(100);
 
-      Logger.info(
-        `Insufficient balance. Minting ${ethers.utils.formatUnits(mintAmount, tokenDecimals)} tokens...`
-      );
+            Logger.info(
+                `Insufficient balance. Minting ${ethers.utils.formatUnits(mintAmount, tokenDecimals)} tokens...`
+            );
 
-      const mintTx = await token.mint(signerAddress, mintAmount);
-      await mintTx.wait();
+            const mintTx = await token.mint(signerAddress, mintAmount);
+            await mintTx.wait();
 
-      Logger.info(`Tokens successfully minted`);
+            Logger.info(`Tokens successfully minted`);
+        }
+
+        // Check allowance
+        const allowance = await token.allowance(signerAddress, routerAddress);
+
+        if (allowance.lt(amount)) {
+            Logger.info(
+                `Approving ${ethers.utils.formatUnits(amount, tokenDecimals)} tokens for router...`
+            );
+
+            const approveTx = await token.approve(routerAddress, ethers.constants.MaxUint256);
+            await approveTx.wait();
+
+            Logger.info(`Tokens successfully approved`);
+        }
+
+        return true;
+    } catch (error) {
+        Logger.error(
+            `Error ensuring token balance: ${error instanceof Error ? error.message : String(error)}`
+        );
+        throw error;
     }
-
-    // Check allowance
-    const allowance = await token.allowance(signerAddress, routerAddress);
-
-    if (allowance.lt(amount)) {
-      Logger.info(
-        `Approving ${ethers.utils.formatUnits(amount, tokenDecimals)} tokens for router...`
-      );
-
-      const approveTx = await token.approve(routerAddress, ethers.constants.MaxUint256);
-      await approveTx.wait();
-
-      Logger.info(`Tokens successfully approved`);
-    }
-
-    return true;
-  } catch (error) {
-    Logger.error(
-      `Error ensuring token balance: ${error instanceof Error ? error.message : String(error)}`
-    );
-    throw error;
-  }
 };
 
 /**
@@ -271,12 +276,12 @@ const ensureTokenBalance = async (
  * @param config - Pool configuration
  */
 const prepareForSwap = async (
-  signer: ethers.Wallet,
-  tokenAddress: string,
-  amount: ethers.BigNumber,
-  config: PoolConfig
+    signer: ethers.Wallet,
+    tokenAddress: string,
+    amount: ethers.BigNumber,
+    config: PoolConfig
 ): Promise<void> => {
-  await ensureTokenBalance(tokenAddress, amount, signer, config.swapRouterAddress);
+    await ensureTokenBalance(tokenAddress, amount, signer, config.swapRouterAddress);
 };
 
 /**
@@ -287,85 +292,104 @@ const prepareForSwap = async (
  * @returns Equivalent BigNumber
  */
 const toBigNumber = (amount: number, decimals: number): ethers.BigNumber => {
-  // Convert scientific notation to regular string
-  const amountStr = amount.toLocaleString('fullwide', { useGrouping: false });
+    // Convert scientific notation to regular string
+    const amountStr = amount.toLocaleString('fullwide', { useGrouping: false });
 
-  // Determine if the number is an integer or has decimals
-  if (!amountStr.includes('.')) {
-    return ethers.utils.parseUnits(amountStr, decimals);
-  }
+    // Determine if the number is an integer or has decimals
+    if (!amountStr.includes('.')) {
+        return ethers.utils.parseUnits(amountStr, decimals);
+    }
 
-  // Handle numbers with decimals
-  const [integerPart, decimalPart] = amountStr.split('.');
-  const paddedDecimalPart = decimalPart.padEnd(decimals, '0').slice(0, decimals);
+    // Handle numbers with decimals
+    const [integerPart, decimalPart] = amountStr.split('.');
+    const paddedDecimalPart = decimalPart.padEnd(decimals, '0').slice(0, decimals);
 
-  return ethers.BigNumber.from(integerPart + paddedDecimalPart);
+    return ethers.BigNumber.from(integerPart + paddedDecimalPart);
 };
 
 /**
  * Main function that executes the pool adjustment logic.
+ * Handles both buying and selling scenarios based on the calculated swap amount.
  */
 async function main() {
-  try {
-    Logger.info('Starting pool adjustment script...');
+    try {
+        Logger.info('Starting pool adjustment script...');
 
-    // Get configuration
-    const config = getConfig();
+        // Get configuration
+        const config = getConfig();
 
-    // Get target price from Coingecko
-    const targetPrice = await coingeckoService.getTokenPrice('ethereum');
-    Logger.info(`Target price: ${targetPrice} USDT per ETH`);
+        // Get target price from Coingecko
+        const targetPrice = await coingeckoService.getTokenPrice('ethereum');
+        Logger.info(`Target price: ${targetPrice} USDT per ETH`);
 
-    // Initialize provider and wallet
-    const provider = new ethers.providers.JsonRpcProvider(config.rpc);
-    const wallet = new ethers.Wallet(config.privateKey, provider);
+        // Initialize provider and wallet
+        const provider = new ethers.providers.JsonRpcProvider(config.rpc);
+        const wallet = new ethers.Wallet(config.privateKey, provider);
 
-    // Get pool balances
-    const { poolBalanceA, poolBalanceB, tokenADecimals } = await getPoolBalances(
-      config.usdtAddress,
-      config.wethAddress,
-      config,
-      provider
-    );
+        // Get pool balances
+        const { poolBalanceA, poolBalanceB, tokenADecimals, tokenBDecimals } = await getPoolBalances(
+            config.usdtAddress,
+            config.wethAddress,
+            config,
+            provider
+        );
 
-    // Calculate amount to swap to reach target price
-    const tokensToSwap = calculateSwapForTargetPrice(poolBalanceA, poolBalanceB, targetPrice);
+        // Calculate amount to swap to reach target price
+        const tokensToSwap = calculateSwapForTargetPrice(poolBalanceA, poolBalanceB, targetPrice);
 
-    // Validate if amount is significant
-    if (tokensToSwap < 1) {
-      Logger.info('Amount to swap is too small to rebalance...');
-      return;
+        // Determine swap direction based on the sign of tokensToSwap
+        const isBuyingTokenA = tokensToSwap > 0;
+
+        // Check if the magnitude is significant enough to warrant a swap
+        if (Math.abs(tokensToSwap) < 1) {
+            Logger.info('Amount to swap is too small to rebalance...');
+            return;
+        }
+
+        // Use absolute value for transaction preparation
+        const absTokensToSwap = Math.abs(tokensToSwap);
+
+        // Determine which token to use as input based on the direction
+        const tokenIn = isBuyingTokenA ? config.wethAddress : config.usdtAddress;
+        const tokenOut = isBuyingTokenA ? config.usdtAddress : config.wethAddress;
+        const tokenDecimals = isBuyingTokenA ? tokenBDecimals : tokenADecimals;
+
+        // For positive tokensToSwap: We need to add USDT to the pool, so we buy USDT with WETH
+        // For negative tokensToSwap: We need to remove USDT from the pool, so we sell USDT for WETH
+
+        // Convert to BigNumber for transactions
+        const swapAmountBN = toBigNumber(absTokensToSwap, tokenDecimals);
+        const swapAmountFormatted = ethers.utils.formatUnits(swapAmountBN, tokenDecimals);
+
+        Logger.info(
+            isBuyingTokenA
+                ? `Swapping ${swapAmountFormatted} WETH for USDT to adjust pool price...`
+                : `Swapping ${swapAmountFormatted} USDT for WETH to adjust pool price...`
+        );
+
+        // Prepare tokens for swap
+        await prepareForSwap(wallet, tokenIn, swapAmountBN, config);
+
+        // Execute swap
+        await executeSwap({
+            config,
+            amountIn: swapAmountFormatted,
+            tokenIn,
+            tokenOut
+        });
+
+        Logger.info('Swap completed successfully.');
+    } catch (error) {
+        Logger.error(`Execution error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
     }
-
-    // Convert to BigNumber for transactions
-    const depositTokenABN = toBigNumber(tokensToSwap, tokenADecimals);
-    const depositTokenAFormatted = ethers.utils.formatUnits(depositTokenABN, tokenADecimals);
-
-    Logger.info(`Swapping ${depositTokenAFormatted} USDT for WETH to adjust pool price...`);
-
-    // Prepare tokens for swap
-    await prepareForSwap(wallet, config.usdtAddress, depositTokenABN, config);
-
-    // Execute swap
-    await executeSwap({
-      config,
-      amountIn: depositTokenAFormatted,
-      tokenIn: config.usdtAddress,
-      tokenOut: config.wethAddress
-    });
-
-    Logger.info('Swap completed successfully.');
-  } catch (error) {
-    Logger.error(`Execution error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(1);
-  }
 }
 
 main()
-  .then(() => process.exit(0))
-  .catch((error) => {
-    Logger.error(`Fatal error: ${error instanceof Error ? error.message : String(error)}`);
-    process.exit(1);
-  });
+    .then(() => process.exit(0))
+    .catch((error) => {
+        Logger.error(`Fatal error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exit(1);
+    });
 
 export { executeSwap };

--- a/scripts/swap_debug/swap_tokens.ts
+++ b/scripts/swap_debug/swap_tokens.ts
@@ -1,7 +1,7 @@
 /**
  * @file swap_tokens.ts
  * @description Execute token swaps using Uniswap V3 on Arbitrum Sepolia testnet
- * 
+ *
  * This module provides a robust interface for executing token swaps via Uniswap V3,
  * with comprehensive error handling, type safety, and runtime validation.
  */
@@ -16,13 +16,13 @@ import { getERC20ABI } from '../../src/services/web3/abiService';
  * Defines network, contract addresses, and transaction parameters
  */
 interface PoolConfig {
-    readonly rpc: string;              // RPC endpoint URL for the network
-    readonly privateKey: string;       // Private key for transaction signing
-    readonly usdtAddress: string;      // USDT token contract address
-    readonly wethAddress: string;      // WETH token contract address 
-    readonly poolFee: number;          // Pool fee in basis points (3000 = 0.3%)
-    readonly swapRouterAddress: string; // Uniswap V3 Router address
-    readonly gasLimit: number;         // Gas limit for swap transactions
+  readonly rpc: string; // RPC endpoint URL for the network
+  readonly privateKey: string; // Private key for transaction signing
+  readonly usdtAddress: string; // USDT token contract address
+  readonly wethAddress: string; // WETH token contract address
+  readonly poolFee: number; // Pool fee in basis points (3000 = 0.3%)
+  readonly swapRouterAddress: string; // Uniswap V3 Router address
+  readonly gasLimit: number; // Gas limit for swap transactions
 }
 
 /**
@@ -30,12 +30,12 @@ interface PoolConfig {
  * Allows overriding default parameters for different swap scenarios
  */
 interface SwapOptions {
-    readonly config?: Partial<PoolConfig>; // Override default configuration
-    readonly amountIn?: string;            // Amount to swap (in token units with decimals)
-    readonly slippageTolerance?: number;   // Slippage tolerance in basis points (e.g., 50 = 0.5%)
-    readonly tokenIn?: string;             // Address of input token (overrides config)
-    readonly tokenOut?: string;            // Address of output token (overrides config)
-    readonly deadline?: number;            // Deadline for transaction execution (seconds from now)
+  readonly config?: Partial<PoolConfig>; // Override default configuration
+  readonly amountIn?: string; // Amount to swap (in token units with decimals)
+  readonly slippageTolerance?: number; // Slippage tolerance in basis points (e.g., 50 = 0.5%)
+  readonly tokenIn?: string; // Address of input token (overrides config)
+  readonly tokenOut?: string; // Address of output token (overrides config)
+  readonly deadline?: number; // Deadline for transaction execution (seconds from now)
 }
 
 /**
@@ -43,14 +43,14 @@ interface SwapOptions {
  * Provides detailed information about the transaction outcome
  */
 interface SwapResult {
-    readonly success: boolean;                    // Whether the swap completed successfully
-    readonly transactionHash?: string;            // Transaction hash if successful
-    readonly gasUsed?: string;                    // Gas used by the transaction
-    readonly error?: string;                      // Error message if not successful
-    readonly amountIn?: string;                   // Input amount in readable format
-    readonly amountOut?: string;                  // Output amount in readable format (if available)
-    readonly inputToken?: string;                 // Input token symbol
-    readonly outputToken?: string;                // Output token symbol
+  readonly success: boolean; // Whether the swap completed successfully
+  readonly transactionHash?: string; // Transaction hash if successful
+  readonly gasUsed?: string; // Gas used by the transaction
+  readonly error?: string; // Error message if not successful
+  readonly amountIn?: string; // Input amount in readable format
+  readonly amountOut?: string; // Output amount in readable format (if available)
+  readonly inputToken?: string; // Input token symbol
+  readonly outputToken?: string; // Output token symbol
 }
 
 /**
@@ -58,99 +58,102 @@ interface SwapResult {
  * Only includes the specific function needed for basic swaps
  */
 const SWAP_ROUTER_ABI = [
-    {
-        "inputs": [
-            {
-                "components": [
-                    { "internalType": "address", "name": "tokenIn", "type": "address" },
-                    { "internalType": "address", "name": "tokenOut", "type": "address" },
-                    { "internalType": "uint24", "name": "fee", "type": "uint24" },
-                    { "internalType": "address", "name": "recipient", "type": "address" },
-                    { "internalType": "uint256", "name": "deadline", "type": "uint256" },
-                    { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
-                    { "internalType": "uint256", "name": "amountOutMinimum", "type": "uint256" },
-                    { "internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160" }
-                ],
-                "internalType": "struct ISwapRouter.ExactInputSingleParams",
-                "name": "params",
-                "type": "tuple"
-            }
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: 'address', name: 'tokenIn', type: 'address' },
+          { internalType: 'address', name: 'tokenOut', type: 'address' },
+          { internalType: 'uint24', name: 'fee', type: 'uint24' },
+          { internalType: 'address', name: 'recipient', type: 'address' },
+          { internalType: 'uint256', name: 'deadline', type: 'uint256' },
+          { internalType: 'uint256', name: 'amountIn', type: 'uint256' },
+          { internalType: 'uint256', name: 'amountOutMinimum', type: 'uint256' },
+          { internalType: 'uint160', name: 'sqrtPriceLimitX96', type: 'uint160' }
         ],
-        "name": "exactInputSingle",
-        "outputs": [{ "internalType": "uint256", "name": "amountOut", "type": "uint256" }],
-        "stateMutability": "payable",
-        "type": "function"
-    }
+        internalType: 'struct ISwapRouter.ExactInputSingleParams',
+        name: 'params',
+        type: 'tuple'
+      }
+    ],
+    name: 'exactInputSingle',
+    outputs: [{ internalType: 'uint256', name: 'amountOut', type: 'uint256' }],
+    stateMutability: 'payable',
+    type: 'function'
+  }
 ];
 
 /**
  * Default configuration with environment fallbacks
  * Used when no custom configuration is provided
- * 
+ *
  * Note: Production code should use environment variables instead of hardcoded values
  */
 const DEFAULT_CONFIG: PoolConfig = {
-    rpc: `https://arb-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY ?? ''}`,
-    privateKey: process.env.SIGNING_KEY ?? '',
-    usdtAddress: process.env.USDT_ADDRESS ?? '0x6D904bB70Cf0CbD427e5e70BCcE1F4D1348b785d',
-    wethAddress: process.env.WETH_ADDRESS ?? '0xd3A5f60cc44b9E51BF7e8D6db882a88260F708BC',
-    poolFee: 3000, // 0.3%
-    swapRouterAddress: process.env.SWAP_ROUTER_ADDRESS ?? '0x101F443B4d1b059569D643917553c771E1b9663E',
-    gasLimit: 3000000,
+  rpc: `https://arb-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY ?? ''}`,
+  privateKey: process.env.SIGNING_KEY ?? '',
+  usdtAddress: process.env.USDT_ADDRESS ?? '0x6D904bB70Cf0CbD427e5e70BCcE1F4D1348b785d',
+  wethAddress: process.env.WETH_ADDRESS ?? '0xd3A5f60cc44b9E51BF7e8D6db882a88260F708BC',
+  poolFee: 3000, // 0.3%
+  swapRouterAddress:
+    process.env.SWAP_ROUTER_ADDRESS ?? '0x101F443B4d1b059569D643917553c771E1b9663E',
+  gasLimit: 3000000
 };
 
 /**
  * Safely gets token information (symbol and decimals) with error handling
- * 
+ *
  * @param tokenContract - ERC20 token contract instance
  * @param fallbackSymbol - Symbol to use if contract call fails
  * @returns Object containing token symbol and decimals
  */
 async function getTokenInfo(
-    tokenContract: ethers.Contract,
-    fallbackSymbol: string = 'UNKNOWN'
+  tokenContract: ethers.Contract,
+  fallbackSymbol: string = 'UNKNOWN'
 ): Promise<{ symbol: string; decimals: number }> {
-    try {
-        // Execute both calls in parallel for efficiency
-        const [symbol, decimals] = await Promise.all([
-            tokenContract.symbol().catch(() => fallbackSymbol),
-            tokenContract.decimals().catch(() => 18) // Most tokens use 18 decimals
-        ]);
+  try {
+    // Execute both calls in parallel for efficiency
+    const [symbol, decimals] = await Promise.all([
+      tokenContract.symbol().catch(() => fallbackSymbol),
+      tokenContract.decimals().catch(() => 18) // Most tokens use 18 decimals
+    ]);
 
-        return { symbol, decimals };
-    } catch (error) {
-        // Fallback to defaults if calls fail
-        Logger.warn(`Failed to get token info: ${error instanceof Error ? error.message : String(error)}`);
-        return { symbol: fallbackSymbol, decimals: 18 };
-    }
+    return { symbol, decimals };
+  } catch (error) {
+    // Fallback to defaults if calls fail
+    Logger.warn(
+      `Failed to get token info: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return { symbol: fallbackSymbol, decimals: 18 };
+  }
 }
 
 /**
  * Calculate minimum output amount based on slippage tolerance
- * 
+ *
  * @param inputAmount - Amount being swapped in wei
  * @param slippageTolerance - Acceptable slippage in basis points
  * @param outputAmount - Expected output amount (if known)
  * @returns Minimum acceptable output amount
  */
 function calculateMinimumOutput(
-    inputAmount: ethers.BigNumber,
-    slippageTolerance: number = 50, // Default to 0.5%
-    outputAmount?: ethers.BigNumber
+  inputAmount: ethers.BigNumber,
+  slippageTolerance: number = 50, // Default to 0.5%
+  outputAmount?: ethers.BigNumber
 ): ethers.BigNumber {
-    // If we already know the expected output, use it with slippage applied
-    if (outputAmount) {
-        const slippageFactor = 10000 - slippageTolerance;
-        return outputAmount.mul(slippageFactor).div(10000);
-    }
+  // If we already know the expected output, use it with slippage applied
+  if (outputAmount) {
+    const slippageFactor = 10000 - slippageTolerance;
+    return outputAmount.mul(slippageFactor).div(10000);
+  }
 
-    // Default to 0 minimum (not recommended for production)
-    return ethers.constants.Zero;
+  // Default to 0 minimum (not recommended for production)
+  return ethers.constants.Zero;
 }
 
 /**
  * Checks token approval and approves if necessary
- * 
+ *
  * @param tokenContract - Token contract instance
  * @param ownerAddress - Address of token owner
  * @param spenderAddress - Address to approve spending
@@ -158,229 +161,237 @@ function calculateMinimumOutput(
  * @param tokenSymbol - Token symbol for logging
  */
 async function ensureTokenApproval(
-    tokenContract: ethers.Contract,
-    ownerAddress: string,
-    spenderAddress: string,
-    amount: ethers.BigNumber,
-    tokenSymbol: string,
-    tokenDecimals: number
+  tokenContract: ethers.Contract,
+  ownerAddress: string,
+  spenderAddress: string,
+  amount: ethers.BigNumber,
+  tokenSymbol: string,
+  tokenDecimals: number
 ): Promise<void> {
-    const allowance = await tokenContract.allowance(ownerAddress, spenderAddress);
+  const allowance = await tokenContract.allowance(ownerAddress, spenderAddress);
 
-    if (allowance.lt(amount)) {
-        Logger.info(`Approving ${ethers.utils.formatUnits(amount, tokenDecimals)} ${tokenSymbol} for router...`);
+  if (allowance.lt(amount)) {
+    Logger.info(
+      `Approving ${ethers.utils.formatUnits(amount, tokenDecimals)} ${tokenSymbol} for router...`
+    );
 
-        const approveTx = await tokenContract.approve(spenderAddress, amount);
-        const receipt = await approveTx.wait();
+    const approveTx = await tokenContract.approve(spenderAddress, amount);
+    const receipt = await approveTx.wait();
 
-        Logger.info(
-            `Approval completed. Hash: ${approveTx.hash}, Gas used: ${receipt.gasUsed.toString()}`
-        );
-    } else {
-        Logger.info(`Sufficient allowance already exists for ${tokenSymbol}`);
-    }
+    Logger.info(
+      `Approval completed. Hash: ${approveTx.hash}, Gas used: ${receipt.gasUsed.toString()}`
+    );
+  } else {
+    Logger.info(`Sufficient allowance already exists for ${tokenSymbol}`);
+  }
 }
 
 /**
  * Execute a token swap on Uniswap V3
- * 
+ *
  * This function handles the entire swap process:
  * 1. Validates inputs and connects to the network
  * 2. Checks token balances and approvals
  * 3. Executes the swap with slippage protection
  * 4. Returns detailed swap results
- * 
+ *
  * @param options - Customization options for the swap
  * @returns Promise resolving to swap execution results
  */
 async function executeSwap(options: SwapOptions = {}): Promise<SwapResult> {
-    try {
-        // Merge provided config with defaults
-        const config = { ...DEFAULT_CONFIG, ...options.config };
+  try {
+    // Merge provided config with defaults
+    const config = { ...DEFAULT_CONFIG, ...options.config };
 
-        // Validate critical config parameters
-        if (!config.privateKey) {
-            throw new Error('Private key is required for signing transactions');
-        }
-
-        // Determine tokens for the swap
-        const tokenInAddress = options.tokenIn ?? config.usdtAddress;
-        const tokenOutAddress = options.tokenOut ?? config.wethAddress;
-
-        if (!ethers.utils.isAddress(tokenInAddress) || !ethers.utils.isAddress(tokenOutAddress)) {
-            throw new Error('Invalid token addresses provided');
-        }
-
-        // Initialize provider and wallet
-        Logger.info(`Connecting to RPC endpoint: ${config.rpc.replace(/\/[a-zA-Z0-9_-]{10,}/, '/***')}`);
-        const provider = new ethers.providers.JsonRpcProvider(config.rpc);
-        const wallet = new ethers.Wallet(config.privateKey, provider);
-
-        Logger.info(`Connected with account: ${wallet.address}`);
-
-        // Initialize contract interfaces
-        const erc20Abi = await getERC20ABI();
-        const tokenInContract = new ethers.Contract(tokenInAddress, erc20Abi, wallet);
-        const tokenOutContract = new ethers.Contract(tokenOutAddress, erc20Abi, wallet);
-        const swapRouterContract = new ethers.Contract(config.swapRouterAddress, SWAP_ROUTER_ABI, wallet);
-
-        // Get token information in parallel for efficiency
-        const [tokenInInfo, tokenOutInfo] = await Promise.all([
-            getTokenInfo(tokenInContract, 'IN-TOKEN'),
-            getTokenInfo(tokenOutContract, 'OUT-TOKEN')
-        ]);
-
-        // Parse input amount with proper decimals
-        const defaultAmount = "1"; // Default to 1 token
-        const amountIn = ethers.utils.parseUnits(options.amountIn ?? defaultAmount, tokenInInfo.decimals);
-        const formattedAmountIn = ethers.utils.formatUnits(amountIn, tokenInInfo.decimals);
-
-        Logger.info(`Preparing to swap ${formattedAmountIn} ${tokenInInfo.symbol} → ${tokenOutInfo.symbol}`);
-
-        // Check if wallet has sufficient balance
-        const balance = await tokenInContract.balanceOf(wallet.address);
-        Logger.info(`Balance: ${ethers.utils.formatUnits(balance, tokenInInfo.decimals)} ${tokenInInfo.symbol}`);
-
-        if (balance.lt(amountIn)) {
-            return {
-                success: false,
-                error: `Insufficient balance. Have ${ethers.utils.formatUnits(balance, tokenInInfo.decimals)} ${tokenInInfo.symbol}, need ${formattedAmountIn}`,
-                inputToken: tokenInInfo.symbol,
-                outputToken: tokenOutInfo.symbol,
-                amountIn: formattedAmountIn
-            };
-        }
-
-        // Ensure router has approval to spend tokens
-        await ensureTokenApproval(
-            tokenInContract,
-            wallet.address,
-            config.swapRouterAddress,
-            amountIn,
-            tokenInInfo.symbol,
-            tokenInInfo.decimals
-        );
-
-        // Calculate deadline for transaction (default: 20 minutes from now)
-        const deadline = Math.floor(Date.now() / 1000) + (options.deadline ?? 1200);
-
-        // Apply slippage tolerance (default: 0.5%)
-        const slippageTolerance = options.slippageTolerance ?? 50;
-        const amountOutMinimum = calculateMinimumOutput(amountIn, slippageTolerance);
-
-        // Prepare swap parameters
-        const params = {
-            tokenIn: tokenInAddress,
-            tokenOut: tokenOutAddress,
-            fee: config.poolFee,
-            recipient: wallet.address,
-            deadline,
-            amountIn,
-            amountOutMinimum,
-            sqrtPriceLimitX96: 0  // No price limit
-        };
-
-        // Execute the swap
-        Logger.info("Executing swap transaction...");
-        const swapTx = await swapRouterContract.exactInputSingle(
-            params,
-            {
-                gasLimit: config.gasLimit,
-                value: 0  // No ETH being sent
-            }
-        );
-
-        Logger.info(`Swap initiated. Transaction hash: ${swapTx.hash}`);
-
-        // Wait for transaction to be mined
-        const receipt = await swapTx.wait();
-
-        // Extract amount out from event logs (if possible)
-        let amountOut: string | undefined;
-        try {
-            // Attempt to find the transfer event for the output token
-            // This is a simplified approach and may not work for all swap scenarios
-            const iface = new ethers.utils.Interface([
-                'event Transfer(address indexed from, address indexed to, uint256 value)'
-            ]);
-
-            const transferLogs = receipt.logs
-                .map((log: {
-                    address: string;
-                    data: string;
-                    topics: string[];
-                }) => {
-                    try {
-                        return {
-                            address: log.address.toLowerCase(),
-                            parsed: iface.parseLog(log)
-                        };
-                    } catch (e) {
-                        return null;
-                    }
-                })
-                .filter((log: {
-                    address: string;
-                    parsed: ethers.utils.LogDescription;
-                }) =>
-                    log !== null &&
-                    log.address.toLowerCase() === tokenOutAddress.toLowerCase() &&
-                    log.parsed.name === 'Transfer' &&
-                    log.parsed.args.to.toLowerCase() === wallet.address.toLowerCase()
-                );
-
-            if (transferLogs.length > 0) {
-                const lastTransferLog = transferLogs[transferLogs.length - 1];
-                amountOut = ethers.utils.formatUnits(
-                    lastTransferLog.parsed.args.value,
-                    tokenOutInfo.decimals
-                );
-            }
-        } catch (error) {
-            Logger.warn(`Could not parse output amount: ${error instanceof Error ? error.message : String(error)}`);
-        }
-
-        Logger.info(`Swap completed successfully. Gas used: ${receipt.gasUsed.toString()}`);
-
-        return {
-            success: true,
-            transactionHash: swapTx.hash,
-            gasUsed: receipt.gasUsed.toString(),
-            amountIn: formattedAmountIn,
-            amountOut,
-            inputToken: tokenInInfo.symbol,
-            outputToken: tokenOutInfo.symbol
-        };
-    } catch (error) {
-        // Comprehensive error handling
-        Logger.error(`Swap execution failed: ${error instanceof Error ? error.message : String(error)}`);
-
-        // Return structured error information
-        return {
-            success: false,
-            error: error instanceof Error
-                ? error.message
-                : 'Unknown error during swap execution'
-        };
+    // Validate critical config parameters
+    if (!config.privateKey) {
+      throw new Error('Private key is required for signing transactions');
     }
+
+    // Determine tokens for the swap
+    const tokenInAddress = options.tokenIn ?? config.usdtAddress;
+    const tokenOutAddress = options.tokenOut ?? config.wethAddress;
+
+    if (!ethers.utils.isAddress(tokenInAddress) || !ethers.utils.isAddress(tokenOutAddress)) {
+      throw new Error('Invalid token addresses provided');
+    }
+
+    // Initialize provider and wallet
+    Logger.info(
+      `Connecting to RPC endpoint: ${config.rpc.replace(/\/[a-zA-Z0-9_-]{10,}/, '/***')}`
+    );
+    const provider = new ethers.providers.JsonRpcProvider(config.rpc);
+    const wallet = new ethers.Wallet(config.privateKey, provider);
+
+    Logger.info(`Connected with account: ${wallet.address}`);
+
+    // Initialize contract interfaces
+    const erc20Abi = await getERC20ABI();
+    const tokenInContract = new ethers.Contract(tokenInAddress, erc20Abi, wallet);
+    const tokenOutContract = new ethers.Contract(tokenOutAddress, erc20Abi, wallet);
+    const swapRouterContract = new ethers.Contract(
+      config.swapRouterAddress,
+      SWAP_ROUTER_ABI,
+      wallet
+    );
+
+    // Get token information in parallel for efficiency
+    const [tokenInInfo, tokenOutInfo] = await Promise.all([
+      getTokenInfo(tokenInContract, 'IN-TOKEN'),
+      getTokenInfo(tokenOutContract, 'OUT-TOKEN')
+    ]);
+
+    // Parse input amount with proper decimals
+    const defaultAmount = '1'; // Default to 1 token
+    const amountIn = ethers.utils.parseUnits(
+      options.amountIn ?? defaultAmount,
+      tokenInInfo.decimals
+    );
+    const formattedAmountIn = ethers.utils.formatUnits(amountIn, tokenInInfo.decimals);
+
+    Logger.info(
+      `Preparing to swap ${formattedAmountIn} ${tokenInInfo.symbol} → ${tokenOutInfo.symbol}`
+    );
+
+    // Check if wallet has sufficient balance
+    const balance = await tokenInContract.balanceOf(wallet.address);
+    Logger.info(
+      `Balance: ${ethers.utils.formatUnits(balance, tokenInInfo.decimals)} ${tokenInInfo.symbol}`
+    );
+
+    if (balance.lt(amountIn)) {
+      return {
+        success: false,
+        error: `Insufficient balance. Have ${ethers.utils.formatUnits(balance, tokenInInfo.decimals)} ${tokenInInfo.symbol}, need ${formattedAmountIn}`,
+        inputToken: tokenInInfo.symbol,
+        outputToken: tokenOutInfo.symbol,
+        amountIn: formattedAmountIn
+      };
+    }
+
+    // Ensure router has approval to spend tokens
+    await ensureTokenApproval(
+      tokenInContract,
+      wallet.address,
+      config.swapRouterAddress,
+      amountIn,
+      tokenInInfo.symbol,
+      tokenInInfo.decimals
+    );
+
+    // Calculate deadline for transaction (default: 20 minutes from now)
+    const deadline = Math.floor(Date.now() / 1000) + (options.deadline ?? 1200);
+
+    // Apply slippage tolerance (default: 0.5%)
+    const slippageTolerance = options.slippageTolerance ?? 50;
+    const amountOutMinimum = calculateMinimumOutput(amountIn, slippageTolerance);
+
+    // Prepare swap parameters
+    const params = {
+      tokenIn: tokenInAddress,
+      tokenOut: tokenOutAddress,
+      fee: config.poolFee,
+      recipient: wallet.address,
+      deadline,
+      amountIn,
+      amountOutMinimum,
+      sqrtPriceLimitX96: 0 // No price limit
+    };
+
+    // Execute the swap
+    Logger.info('Executing swap transaction...');
+    const swapTx = await swapRouterContract.exactInputSingle(params, {
+      gasLimit: config.gasLimit,
+      value: 0 // No ETH being sent
+    });
+
+    Logger.info(`Swap initiated. Transaction hash: ${swapTx.hash}`);
+
+    // Wait for transaction to be mined
+    const receipt = await swapTx.wait();
+
+    // Extract amount out from event logs (if possible)
+    let amountOut: string | undefined;
+    try {
+      // Attempt to find the transfer event for the output token
+      // This is a simplified approach and may not work for all swap scenarios
+      const iface = new ethers.utils.Interface([
+        'event Transfer(address indexed from, address indexed to, uint256 value)'
+      ]);
+
+      const transferLogs = receipt.logs
+        .map((log: { address: string; data: string; topics: string[] }) => {
+          try {
+            return {
+              address: log.address.toLowerCase(),
+              parsed: iface.parseLog(log)
+            };
+          } catch (e) {
+            return null;
+          }
+        })
+        .filter(
+          (log: { address: string; parsed: ethers.utils.LogDescription }) =>
+            log !== null &&
+            log.address.toLowerCase() === tokenOutAddress.toLowerCase() &&
+            log.parsed.name === 'Transfer' &&
+            log.parsed.args.to.toLowerCase() === wallet.address.toLowerCase()
+        );
+
+      if (transferLogs.length > 0) {
+        const lastTransferLog = transferLogs[transferLogs.length - 1];
+        amountOut = ethers.utils.formatUnits(
+          lastTransferLog.parsed.args.value,
+          tokenOutInfo.decimals
+        );
+      }
+    } catch (error) {
+      Logger.warn(
+        `Could not parse output amount: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    Logger.info(`Swap completed successfully. Gas used: ${receipt.gasUsed.toString()}`);
+
+    return {
+      success: true,
+      transactionHash: swapTx.hash,
+      gasUsed: receipt.gasUsed.toString(),
+      amountIn: formattedAmountIn,
+      amountOut,
+      inputToken: tokenInInfo.symbol,
+      outputToken: tokenOutInfo.symbol
+    };
+  } catch (error) {
+    // Comprehensive error handling
+    Logger.error(
+      `Swap execution failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+
+    // Return structured error information
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error during swap execution'
+    };
+  }
 }
 
 // Execute main function if running directly
 if (require.main === module) {
-    executeSwap({
-        amountIn: "1",
-        tokenIn: DEFAULT_CONFIG.wethAddress,
-        tokenOut: DEFAULT_CONFIG.usdtAddress,
-        slippageTolerance: 100  // 1% slippage tolerance
+  executeSwap({
+    amountIn: '1',
+    tokenIn: DEFAULT_CONFIG.wethAddress,
+    tokenOut: DEFAULT_CONFIG.usdtAddress,
+    slippageTolerance: 100 // 1% slippage tolerance
+  })
+    .then((result) => {
+      Logger.info('Swap result:', result);
+      process.exit(0);
     })
-        .then(result => {
-            Logger.info("Swap result:", result);
-            process.exit(0);
-        })
-        .catch(error => {
-            Logger.error("Fatal error:", error);
-            process.exit(1);
-        });
+    .catch((error) => {
+      Logger.error('Fatal error:', error);
+      process.exit(1);
+    });
 }
 
 // Export for use in other modules

--- a/scripts/swap_debug/swap_tokens.ts
+++ b/scripts/swap_debug/swap_tokens.ts
@@ -1,0 +1,387 @@
+/**
+ * @file swap_tokens.ts
+ * @description Execute token swaps using Uniswap V3 on Arbitrum Sepolia testnet
+ * 
+ * This module provides a robust interface for executing token swaps via Uniswap V3,
+ * with comprehensive error handling, type safety, and runtime validation.
+ */
+
+import { ethers } from 'ethers';
+
+import { Logger } from '../../src/helpers/loggerHelper';
+import { getERC20ABI } from '../../src/services/web3/abiService';
+
+/**
+ * Configuration for the swap execution environment
+ * Defines network, contract addresses, and transaction parameters
+ */
+interface PoolConfig {
+    readonly rpc: string;              // RPC endpoint URL for the network
+    readonly privateKey: string;       // Private key for transaction signing
+    readonly usdtAddress: string;      // USDT token contract address
+    readonly wethAddress: string;      // WETH token contract address 
+    readonly poolFee: number;          // Pool fee in basis points (3000 = 0.3%)
+    readonly swapRouterAddress: string; // Uniswap V3 Router address
+    readonly gasLimit: number;         // Gas limit for swap transactions
+}
+
+/**
+ * Options for customizing swap execution
+ * Allows overriding default parameters for different swap scenarios
+ */
+interface SwapOptions {
+    readonly config?: Partial<PoolConfig>; // Override default configuration
+    readonly amountIn?: string;            // Amount to swap (in token units with decimals)
+    readonly slippageTolerance?: number;   // Slippage tolerance in basis points (e.g., 50 = 0.5%)
+    readonly tokenIn?: string;             // Address of input token (overrides config)
+    readonly tokenOut?: string;            // Address of output token (overrides config)
+    readonly deadline?: number;            // Deadline for transaction execution (seconds from now)
+}
+
+/**
+ * Result of a swap execution
+ * Provides detailed information about the transaction outcome
+ */
+interface SwapResult {
+    readonly success: boolean;                    // Whether the swap completed successfully
+    readonly transactionHash?: string;            // Transaction hash if successful
+    readonly gasUsed?: string;                    // Gas used by the transaction
+    readonly error?: string;                      // Error message if not successful
+    readonly amountIn?: string;                   // Input amount in readable format
+    readonly amountOut?: string;                  // Output amount in readable format (if available)
+    readonly inputToken?: string;                 // Input token symbol
+    readonly outputToken?: string;                // Output token symbol
+}
+
+/**
+ * Simplified ABI for Uniswap V3 Router's exactInputSingle function
+ * Only includes the specific function needed for basic swaps
+ */
+const SWAP_ROUTER_ABI = [
+    {
+        "inputs": [
+            {
+                "components": [
+                    { "internalType": "address", "name": "tokenIn", "type": "address" },
+                    { "internalType": "address", "name": "tokenOut", "type": "address" },
+                    { "internalType": "uint24", "name": "fee", "type": "uint24" },
+                    { "internalType": "address", "name": "recipient", "type": "address" },
+                    { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+                    { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+                    { "internalType": "uint256", "name": "amountOutMinimum", "type": "uint256" },
+                    { "internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160" }
+                ],
+                "internalType": "struct ISwapRouter.ExactInputSingleParams",
+                "name": "params",
+                "type": "tuple"
+            }
+        ],
+        "name": "exactInputSingle",
+        "outputs": [{ "internalType": "uint256", "name": "amountOut", "type": "uint256" }],
+        "stateMutability": "payable",
+        "type": "function"
+    }
+];
+
+/**
+ * Default configuration with environment fallbacks
+ * Used when no custom configuration is provided
+ * 
+ * Note: Production code should use environment variables instead of hardcoded values
+ */
+const DEFAULT_CONFIG: PoolConfig = {
+    rpc: `https://arb-sepolia.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY ?? ''}`,
+    privateKey: process.env.SIGNING_KEY ?? '',
+    usdtAddress: process.env.USDT_ADDRESS ?? '0x6D904bB70Cf0CbD427e5e70BCcE1F4D1348b785d',
+    wethAddress: process.env.WETH_ADDRESS ?? '0xd3A5f60cc44b9E51BF7e8D6db882a88260F708BC',
+    poolFee: 3000, // 0.3%
+    swapRouterAddress: process.env.SWAP_ROUTER_ADDRESS ?? '0x101F443B4d1b059569D643917553c771E1b9663E',
+    gasLimit: 3000000,
+};
+
+/**
+ * Safely gets token information (symbol and decimals) with error handling
+ * 
+ * @param tokenContract - ERC20 token contract instance
+ * @param fallbackSymbol - Symbol to use if contract call fails
+ * @returns Object containing token symbol and decimals
+ */
+async function getTokenInfo(
+    tokenContract: ethers.Contract,
+    fallbackSymbol: string = 'UNKNOWN'
+): Promise<{ symbol: string; decimals: number }> {
+    try {
+        // Execute both calls in parallel for efficiency
+        const [symbol, decimals] = await Promise.all([
+            tokenContract.symbol().catch(() => fallbackSymbol),
+            tokenContract.decimals().catch(() => 18) // Most tokens use 18 decimals
+        ]);
+
+        return { symbol, decimals };
+    } catch (error) {
+        // Fallback to defaults if calls fail
+        Logger.warn(`Failed to get token info: ${error instanceof Error ? error.message : String(error)}`);
+        return { symbol: fallbackSymbol, decimals: 18 };
+    }
+}
+
+/**
+ * Calculate minimum output amount based on slippage tolerance
+ * 
+ * @param inputAmount - Amount being swapped in wei
+ * @param slippageTolerance - Acceptable slippage in basis points
+ * @param outputAmount - Expected output amount (if known)
+ * @returns Minimum acceptable output amount
+ */
+function calculateMinimumOutput(
+    inputAmount: ethers.BigNumber,
+    slippageTolerance: number = 50, // Default to 0.5%
+    outputAmount?: ethers.BigNumber
+): ethers.BigNumber {
+    // If we already know the expected output, use it with slippage applied
+    if (outputAmount) {
+        const slippageFactor = 10000 - slippageTolerance;
+        return outputAmount.mul(slippageFactor).div(10000);
+    }
+
+    // Default to 0 minimum (not recommended for production)
+    return ethers.constants.Zero;
+}
+
+/**
+ * Checks token approval and approves if necessary
+ * 
+ * @param tokenContract - Token contract instance
+ * @param ownerAddress - Address of token owner
+ * @param spenderAddress - Address to approve spending
+ * @param amount - Amount to approve
+ * @param tokenSymbol - Token symbol for logging
+ */
+async function ensureTokenApproval(
+    tokenContract: ethers.Contract,
+    ownerAddress: string,
+    spenderAddress: string,
+    amount: ethers.BigNumber,
+    tokenSymbol: string,
+    tokenDecimals: number
+): Promise<void> {
+    const allowance = await tokenContract.allowance(ownerAddress, spenderAddress);
+
+    if (allowance.lt(amount)) {
+        Logger.info(`Approving ${ethers.utils.formatUnits(amount, tokenDecimals)} ${tokenSymbol} for router...`);
+
+        const approveTx = await tokenContract.approve(spenderAddress, amount);
+        const receipt = await approveTx.wait();
+
+        Logger.info(
+            `Approval completed. Hash: ${approveTx.hash}, Gas used: ${receipt.gasUsed.toString()}`
+        );
+    } else {
+        Logger.info(`Sufficient allowance already exists for ${tokenSymbol}`);
+    }
+}
+
+/**
+ * Execute a token swap on Uniswap V3
+ * 
+ * This function handles the entire swap process:
+ * 1. Validates inputs and connects to the network
+ * 2. Checks token balances and approvals
+ * 3. Executes the swap with slippage protection
+ * 4. Returns detailed swap results
+ * 
+ * @param options - Customization options for the swap
+ * @returns Promise resolving to swap execution results
+ */
+async function executeSwap(options: SwapOptions = {}): Promise<SwapResult> {
+    try {
+        // Merge provided config with defaults
+        const config = { ...DEFAULT_CONFIG, ...options.config };
+
+        // Validate critical config parameters
+        if (!config.privateKey) {
+            throw new Error('Private key is required for signing transactions');
+        }
+
+        // Determine tokens for the swap
+        const tokenInAddress = options.tokenIn ?? config.usdtAddress;
+        const tokenOutAddress = options.tokenOut ?? config.wethAddress;
+
+        if (!ethers.utils.isAddress(tokenInAddress) || !ethers.utils.isAddress(tokenOutAddress)) {
+            throw new Error('Invalid token addresses provided');
+        }
+
+        // Initialize provider and wallet
+        Logger.info(`Connecting to RPC endpoint: ${config.rpc.replace(/\/[a-zA-Z0-9_-]{10,}/, '/***')}`);
+        const provider = new ethers.providers.JsonRpcProvider(config.rpc);
+        const wallet = new ethers.Wallet(config.privateKey, provider);
+
+        Logger.info(`Connected with account: ${wallet.address}`);
+
+        // Initialize contract interfaces
+        const erc20Abi = await getERC20ABI();
+        const tokenInContract = new ethers.Contract(tokenInAddress, erc20Abi, wallet);
+        const tokenOutContract = new ethers.Contract(tokenOutAddress, erc20Abi, wallet);
+        const swapRouterContract = new ethers.Contract(config.swapRouterAddress, SWAP_ROUTER_ABI, wallet);
+
+        // Get token information in parallel for efficiency
+        const [tokenInInfo, tokenOutInfo] = await Promise.all([
+            getTokenInfo(tokenInContract, 'IN-TOKEN'),
+            getTokenInfo(tokenOutContract, 'OUT-TOKEN')
+        ]);
+
+        // Parse input amount with proper decimals
+        const defaultAmount = "1"; // Default to 1 token
+        const amountIn = ethers.utils.parseUnits(options.amountIn ?? defaultAmount, tokenInInfo.decimals);
+        const formattedAmountIn = ethers.utils.formatUnits(amountIn, tokenInInfo.decimals);
+
+        Logger.info(`Preparing to swap ${formattedAmountIn} ${tokenInInfo.symbol} → ${tokenOutInfo.symbol}`);
+
+        // Check if wallet has sufficient balance
+        const balance = await tokenInContract.balanceOf(wallet.address);
+        Logger.info(`Balance: ${ethers.utils.formatUnits(balance, tokenInInfo.decimals)} ${tokenInInfo.symbol}`);
+
+        if (balance.lt(amountIn)) {
+            return {
+                success: false,
+                error: `Insufficient balance. Have ${ethers.utils.formatUnits(balance, tokenInInfo.decimals)} ${tokenInInfo.symbol}, need ${formattedAmountIn}`,
+                inputToken: tokenInInfo.symbol,
+                outputToken: tokenOutInfo.symbol,
+                amountIn: formattedAmountIn
+            };
+        }
+
+        // Ensure router has approval to spend tokens
+        await ensureTokenApproval(
+            tokenInContract,
+            wallet.address,
+            config.swapRouterAddress,
+            amountIn,
+            tokenInInfo.symbol,
+            tokenInInfo.decimals
+        );
+
+        // Calculate deadline for transaction (default: 20 minutes from now)
+        const deadline = Math.floor(Date.now() / 1000) + (options.deadline ?? 1200);
+
+        // Apply slippage tolerance (default: 0.5%)
+        const slippageTolerance = options.slippageTolerance ?? 50;
+        const amountOutMinimum = calculateMinimumOutput(amountIn, slippageTolerance);
+
+        // Prepare swap parameters
+        const params = {
+            tokenIn: tokenInAddress,
+            tokenOut: tokenOutAddress,
+            fee: config.poolFee,
+            recipient: wallet.address,
+            deadline,
+            amountIn,
+            amountOutMinimum,
+            sqrtPriceLimitX96: 0  // No price limit
+        };
+
+        // Execute the swap
+        Logger.info("Executing swap transaction...");
+        const swapTx = await swapRouterContract.exactInputSingle(
+            params,
+            {
+                gasLimit: config.gasLimit,
+                value: 0  // No ETH being sent
+            }
+        );
+
+        Logger.info(`Swap initiated. Transaction hash: ${swapTx.hash}`);
+
+        // Wait for transaction to be mined
+        const receipt = await swapTx.wait();
+
+        // Extract amount out from event logs (if possible)
+        let amountOut: string | undefined;
+        try {
+            // Attempt to find the transfer event for the output token
+            // This is a simplified approach and may not work for all swap scenarios
+            const iface = new ethers.utils.Interface([
+                'event Transfer(address indexed from, address indexed to, uint256 value)'
+            ]);
+
+            const transferLogs = receipt.logs
+                .map((log: {
+                    address: string;
+                    data: string;
+                    topics: string[];
+                }) => {
+                    try {
+                        return {
+                            address: log.address.toLowerCase(),
+                            parsed: iface.parseLog(log)
+                        };
+                    } catch (e) {
+                        return null;
+                    }
+                })
+                .filter((log: {
+                    address: string;
+                    parsed: ethers.utils.LogDescription;
+                }) =>
+                    log !== null &&
+                    log.address.toLowerCase() === tokenOutAddress.toLowerCase() &&
+                    log.parsed.name === 'Transfer' &&
+                    log.parsed.args.to.toLowerCase() === wallet.address.toLowerCase()
+                );
+
+            if (transferLogs.length > 0) {
+                const lastTransferLog = transferLogs[transferLogs.length - 1];
+                amountOut = ethers.utils.formatUnits(
+                    lastTransferLog.parsed.args.value,
+                    tokenOutInfo.decimals
+                );
+            }
+        } catch (error) {
+            Logger.warn(`Could not parse output amount: ${error instanceof Error ? error.message : String(error)}`);
+        }
+
+        Logger.info(`Swap completed successfully. Gas used: ${receipt.gasUsed.toString()}`);
+
+        return {
+            success: true,
+            transactionHash: swapTx.hash,
+            gasUsed: receipt.gasUsed.toString(),
+            amountIn: formattedAmountIn,
+            amountOut,
+            inputToken: tokenInInfo.symbol,
+            outputToken: tokenOutInfo.symbol
+        };
+    } catch (error) {
+        // Comprehensive error handling
+        Logger.error(`Swap execution failed: ${error instanceof Error ? error.message : String(error)}`);
+
+        // Return structured error information
+        return {
+            success: false,
+            error: error instanceof Error
+                ? error.message
+                : 'Unknown error during swap execution'
+        };
+    }
+}
+
+// Execute main function if running directly
+if (require.main === module) {
+    executeSwap({
+        amountIn: "1",
+        tokenIn: DEFAULT_CONFIG.wethAddress,
+        tokenOut: DEFAULT_CONFIG.usdtAddress,
+        slippageTolerance: 100  // 1% slippage tolerance
+    })
+        .then(result => {
+            Logger.info("Swap result:", result);
+            process.exit(0);
+        })
+        .catch(error => {
+            Logger.error("Fatal error:", error);
+            process.exit(1);
+        });
+}
+
+// Export for use in other modules
+export { SwapResult, PoolConfig, executeSwap, SwapOptions };

--- a/src/services/swapService.ts
+++ b/src/services/swapService.ts
@@ -201,8 +201,8 @@ function calculateExpectedOutput(
   Logger.debug(
     'calculateExpectedOutput',
     `Calculating expected output. Swap amount: ${swapAmount.toString()}, ` +
-      `Price in: ${priceIn}, Price out: ${priceOut}, ` +
-      `Decimals in: ${decimalsIn}, Decimals out: ${decimalsOut}`
+    `Price in: ${priceIn}, Price out: ${priceOut}, ` +
+    `Decimals in: ${decimalsIn}, Decimals out: ${decimalsOut}`
   );
 
   // Add validation to prevent division by zero
@@ -370,8 +370,8 @@ export async function executeSwap(
     );
     Logger.debug('executeSwap', `Fee in cents: ${feeInCents.toString()}`);
 
-    let effectivePriceIn = 1;
-    let effectivePriceOut = 5;
+    let effectivePriceIn = 0;
+    let effectivePriceOut = 0;
 
     // Keep Paymater Deposit Value
     const paymasterDepositValuePrev = await getPaymasterEntryPointDepositValue(
@@ -428,7 +428,6 @@ export async function executeSwap(
         'Test environment detected - using price ratio with high slippage'
       );
     }
-
     // Calculate fee and amounts
     const feeInTokenIn = calculateFeeInToken(feeInCents, tokenInDecimals, effectivePriceIn);
     Logger.debug('executeSwap', `Fee in input token: ${feeInTokenIn.toString()}`);
@@ -445,6 +444,7 @@ export async function executeSwap(
       tokenInDecimals,
       tokenOutDecimals
     );
+
     Logger.info('executeSwap', `Expected output amount: ${expectedOutput.toString()}`);
 
     const isOutStable = tokenInfo?.type === 'stable';
@@ -480,7 +480,7 @@ export async function executeSwap(
       tokenIn,
       tokenOut,
       amountInBN,
-      amountOutMin,
+      isTestNetwork ? ethers.constants.Zero : amountOutMin,
       recipient
     );
 

--- a/src/services/swapService.ts
+++ b/src/services/swapService.ts
@@ -429,7 +429,10 @@ export async function executeSwap(
       );
     }
     // Calculate fee and amounts
-    const feeInTokenIn = calculateFeeInToken(feeInCents, tokenInDecimals, effectivePriceIn);
+    const feeInTokenIn = isTestNetwork
+      ? ethers.constants.Zero
+      : calculateFeeInToken(feeInCents, tokenInDecimals, effectivePriceIn);
+
     Logger.debug('executeSwap', `Fee in input token: ${feeInTokenIn.toString()}`);
 
     const amountInBN = ethers.utils.parseUnits(amount, tokenInDecimals);
@@ -437,13 +440,15 @@ export async function executeSwap(
     Logger.info('executeSwap', `Swap amount after fee: ${swapAmount.toString()}`);
 
     // Calculate expected output with price adjustment
-    const expectedOutput = calculateExpectedOutput(
-      swapAmount,
-      effectivePriceIn,
-      effectivePriceOut,
-      tokenInDecimals,
-      tokenOutDecimals
-    );
+    const expectedOutput = isTestNetwork
+      ? ethers.constants.Zero
+      : calculateExpectedOutput(
+        swapAmount,
+        effectivePriceIn,
+        effectivePriceOut,
+        tokenInDecimals,
+        tokenOutDecimals
+      );
 
     Logger.info('executeSwap', `Expected output amount: ${expectedOutput.toString()}`);
 
@@ -480,7 +485,7 @@ export async function executeSwap(
       tokenIn,
       tokenOut,
       amountInBN,
-      isTestNetwork ? ethers.constants.Zero : amountOutMin,
+      amountOutMin,
       recipient
     );
 
@@ -518,7 +523,7 @@ export async function executeSwap(
     );
     return {
       success: true,
-      approveTransactionHash: approveTrxHash || '',
+      approveTransactionHash: approveTrxHash ?? '',
       swapTransactionHash: swapTransactionResult.transactionHash
     };
   } catch (error) {

--- a/src/services/swapService.ts
+++ b/src/services/swapService.ts
@@ -201,8 +201,8 @@ function calculateExpectedOutput(
   Logger.debug(
     'calculateExpectedOutput',
     `Calculating expected output. Swap amount: ${swapAmount.toString()}, ` +
-    `Price in: ${priceIn}, Price out: ${priceOut}, ` +
-    `Decimals in: ${decimalsIn}, Decimals out: ${decimalsOut}`
+      `Price in: ${priceIn}, Price out: ${priceOut}, ` +
+      `Decimals in: ${decimalsIn}, Decimals out: ${decimalsOut}`
   );
 
   // Add validation to prevent division by zero
@@ -443,12 +443,12 @@ export async function executeSwap(
     const expectedOutput = isTestNetwork
       ? ethers.constants.Zero
       : calculateExpectedOutput(
-        swapAmount,
-        effectivePriceIn,
-        effectivePriceOut,
-        tokenInDecimals,
-        tokenOutDecimals
-      );
+          swapAmount,
+          effectivePriceIn,
+          effectivePriceOut,
+          tokenInDecimals,
+          tokenOutDecimals
+        );
 
     Logger.info('executeSwap', `Expected output amount: ${expectedOutput.toString()}`);
 


### PR DESCRIPTION
## Changelog
1. Testnet pool relation improved to reflect ETH price. ~$1850 USD @ ETH. [Direct TX](https://sepolia.arbiscan.io/tx/0xda5c8ce8c9e3d5236ae06c99a96e3c0dc45637c07cd6906187961392cf471cf2) | [TX Using new contracts](https://sepolia.arbiscan.io/tx/0x4ed3799724ace46ac9aa2cb2ad3c3a79b6ef2b03b4be3edc4402828c9890d7fb)
2. Added and documented a script to make this price update automatic calculating the necessary USDT amount to be minted and bought.
3. Removed price and min amount protection in testnets because the pools use test tokens that will never reflect the real value (although we can approximate it periodically with the new script), and the price feeds are not updated as frequently. The checks in mainnet remains unchanged

### Pool Adjustment script
Added a script in `/scripts/swap_debug/adjust_pool.ts` that dynamically adjusts Uniswap pool prices to target the current ETH/USD price by executing optimal token swaps in either direction.

Usage: `bun run .\scripts\swap_debug\adjust_pool.ts`

## Formula

The constant product AMM:

$$k = r_0 \cdot r_1$$

New reserves to reach the target price:

$$r_1' = \sqrt{\frac{k}{P_{target}}} = \sqrt{\frac{r_0 \cdot r_1}{P_{target}}}$$

$$r_0' = P_{target} \cdot r_1' = \sqrt{P_{target} \cdot r_0 \cdot r_1}$$

Amount of tokens to swap (positive = buy, negative = sell):

$$\Delta_{tokens} = r_0' - r_0$$

----

## Close

- #418 