### PR TITLE
merge feature/remove-bundler-url into develop

### DIFF
--- a/src/models/blockchainModel.ts
+++ b/src/models/blockchainModel.ts
@@ -27,7 +27,6 @@ export interface IBlockchain extends Document {
   manteca_name: string;
   chainId: number;
   rpc: string;
-  bundlerUrl?: string;
   logo: string;
   explorer: string;
   marketplaceOpenseaUrl: string;
@@ -87,7 +86,6 @@ const blockchainSchema = new Schema<IBlockchain>({
   manteca_name: { type: String, required: true },
   chainId: { type: Number, required: true },
   rpc: { type: String, required: true },
-  bundlerUrl: { type: String, required: false },
   logo: { type: String, required: true },
   explorer: { type: String, required: true },
   marketplaceOpenseaUrl: { type: String, required: true },

--- a/src/services/web3/bundlerService.ts
+++ b/src/services/web3/bundlerService.ts
@@ -53,7 +53,7 @@ export async function sendUserOperationToBundler(
     };
     Logger.log(
       'sendUserOperationToBundler',
-      `payload: ${JSON.stringify(payload)}, bundlerUrl: ${rpcUrl}`
+      `payload: ${JSON.stringify(payload)}, rpcUrl: ${rpcUrl}`
     );
 
     // Wrapper function in quue to avoid erro 429 (rate-limit)

--- a/src/services/web3/contractSetupService.ts
+++ b/src/services/web3/contractSetupService.ts
@@ -1,28 +1,11 @@
 import { ethers } from 'ethers';
 
-import { Logger } from '../../helpers/loggerHelper';
 import { SIGNING_KEY } from '../../config/constants';
 import { IBlockchain } from '../../models/blockchainModel';
 import { SetupContractReturn } from '../../types/commonType';
 import { getERC20ABI, getChatterpayABI } from './abiService';
 import { computeProxyAddressFromPhone } from '../predictWalletService';
 import { mongoBlockchainService } from '../mongo/mongoBlockchainService';
-
-/**
- * Validate Bundle Url
- * @param url
- * @returns
- */
-async function validateBundlerUrl(url: string): Promise<boolean> {
-  try {
-    const provider = new ethers.providers.JsonRpcProvider(url);
-    await provider.getNetwork();
-    return true;
-  } catch (error) {
-    Logger.error('validateBundlerUrl', `Failed to validate bundler URL ${url}:`, error);
-    return false;
-  }
-}
 
 /**
  * Sets up the necessary contracts and providers for blockchain interaction.
@@ -55,7 +38,6 @@ export async function setupContracts(
     provider,
     signer,
     backendSigner,
-    bundlerUrl: rpUrl,
     chatterPay: chatterPayContract,
     proxy,
     accountExists

--- a/src/services/web3/contractSetupService.ts
+++ b/src/services/web3/contractSetupService.ts
@@ -37,17 +37,6 @@ export async function setupContracts(
   privateKey: string,
   fromNumber: string
 ): Promise<SetupContractReturn> {
-  const rpUrl = blockchain.rpc;
-  if (!rpUrl) {
-    throw new Error(`Unsupported chain ID: ${blockchain.chainId}`);
-  }
-
-  Logger.log('setupContracts', `Validating RPC URL: ${rpUrl}`);
-  const isValidBundler = await validateBundlerUrl(rpUrl);
-  if (!isValidBundler) {
-    throw new Error(`Invalid or unreachable RPC URL: ${rpUrl}`);
-  }
-
   const network = await mongoBlockchainService.getNetworkConfig();
   const provider = new ethers.providers.JsonRpcProvider(network.rpc);
   const signer = new ethers.Wallet(privateKey, provider);

--- a/src/services/web3/userOperationService.ts
+++ b/src/services/web3/userOperationService.ts
@@ -315,9 +315,8 @@ async function prepareAndExecuteUserOperation(
     }
 
     // Send the operation to the bundler and wait for receipt
-    Logger.info(userOpType, `Sending operation to bundler: ${networkConfig.bundlerUrl}`);
+    Logger.info(userOpType, `Sending operation to bundler: ${networkConfig.rpc}`);
     const bundlerResponse = await sendUserOperationToBundler(
-      // networkConfig.bundlerUrl!,
       networkConfig.rpc,
       userOperation,
       entryPointContract.address

--- a/src/types/commonType.ts
+++ b/src/types/commonType.ts
@@ -75,7 +75,6 @@ export interface SetupContractReturn {
   provider: ethers.providers.JsonRpcProvider;
   signer: ethers.Wallet;
   backendSigner: ethers.Wallet;
-  bundlerUrl: string;
   chatterPay: ethers.Contract;
   proxy: ComputedAddress;
   accountExists: boolean;


### PR DESCRIPTION
- [refactor] :fire: remove deprecated getPaymasterAndData function in gasService 
- [refactor] :fire: remove deprecated bundlerUrl function in setupContracts
- [refactor] :fire: remove unused bundlerUrl validation in setupContracts 
- [refactor] :recycle: replace bundlerUrl with rpcUrl in logger 
- [refactor] :label: remove bundlerUrl from blockchain model 
- [refactor] :label: remove bundleUrl from commonType