### PR TITLE
merge feature/chain-id-in-transactions into develop

### DIFF
--- a/src/controllers/balanceController.ts
+++ b/src/controllers/balanceController.ts
@@ -29,7 +29,11 @@ import {
 export const checkExternalDeposits = async (request: FastifyRequest, reply: FastifyReply) => {
   const fastify = request.server;
   const { routerAddress } = fastify.networkConfig.contracts;
-  const depositsStatus = await fetchExternalDeposits('ARBITRUM_SEPOLIA', routerAddress!);
+  const depositsStatus = await fetchExternalDeposits(
+    'ARBITRUM_SEPOLIA',
+    routerAddress!,
+    fastify.networkConfig.chainId
+  );
   return returnSuccessResponse(reply, depositsStatus);
 };
 

--- a/src/controllers/swapController.ts
+++ b/src/controllers/swapController.ts
@@ -262,7 +262,8 @@ export const swap = async (
       amount: fromTokensSentInUnits,
       token: inputCurrency,
       type: 'swap',
-      status: 'completed'
+      status: 'completed',
+      chain_id: request.server.networkConfig.chainId
     };
     await mongoTransactionService.saveTransaction(transactionOut);
 
@@ -274,7 +275,8 @@ export const swap = async (
       amount: toTokensReceivedInUnits,
       token: outputCurrency,
       type: 'swap',
-      status: 'completed'
+      status: 'completed',
+      chain_id: request.server.networkConfig.chainId
     };
     await mongoTransactionService.saveTransaction(transactionIn);
 

--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -530,7 +530,8 @@ export const makeTransaction = async (
       amount: parseFloat(amount),
       token: tokenSymbol,
       type: 'transfer',
-      status: 'completed'
+      status: 'completed',
+      chain_id: request.server.networkConfig.chainId
     };
     await mongoTransactionService.saveTransaction(transactionOut);
     saveTransactionSpan?.endSpan();

--- a/src/models/transactionModel.ts
+++ b/src/models/transactionModel.ts
@@ -9,6 +9,7 @@ export interface ITransaction extends Document {
   status: string;
   amount: number;
   token: string;
+  chain_id: number;
 }
 
 const transactionSchema = new Schema<ITransaction>({
@@ -19,7 +20,8 @@ const transactionSchema = new Schema<ITransaction>({
   date: { type: Date, required: true },
   status: { type: String, required: true },
   amount: { type: Number, required: true },
-  token: { type: String, required: true }
+  token: { type: String, required: true },
+  chain_id: { type: Number, required: true }
 });
 
 transactionSchema.index(

--- a/src/services/mongo/mongoTransactionService.ts
+++ b/src/services/mongo/mongoTransactionService.ts
@@ -8,7 +8,7 @@ export const mongoTransactionService = {
    */
   saveTransaction: async (transactionData: TransactionData) => {
     try {
-      const { tx, walletFrom, walletTo, amount, token, type, status } = transactionData;
+      const { tx, walletFrom, walletTo, amount, token, type, status, chain_id } = transactionData;
 
       await Transaction.create({
         trx_hash: tx,
@@ -18,7 +18,8 @@ export const mongoTransactionService = {
         date: new Date(),
         status,
         amount,
-        token
+        token,
+        chain_id
       });
     } catch (error: unknown) {
       // avoid throw error

--- a/src/services/transferService.ts
+++ b/src/services/transferService.ts
@@ -219,7 +219,8 @@ export async function withdrawWalletAllFunds(
           amount,
           token: symbol,
           type: 'withdraw',
-          status: 'completed'
+          status: 'completed',
+          chain_id: networkConfig.chainId
         });
 
         // Only if it's not the last one

--- a/src/types/commonType.ts
+++ b/src/types/commonType.ts
@@ -96,6 +96,7 @@ export interface TransactionData {
   token: string;
   type: string;
   status: string;
+  chain_id: number;
 }
 
 export interface ConversionRates {

--- a/test/models/transactionModel.test.ts
+++ b/test/models/transactionModel.test.ts
@@ -32,7 +32,8 @@ describe('Transaction Model', () => {
       date: new Date(),
       status: 'completed',
       amount: 100.5,
-      token: 'ETH'
+      token: 'ETH',
+      chain_id: 1
     };
 
     const transaction = new Transaction(validTransaction);
@@ -47,6 +48,7 @@ describe('Transaction Model', () => {
     expect(savedTransaction.status).toBe(validTransaction.status);
     expect(savedTransaction.amount).toBe(validTransaction.amount);
     expect(savedTransaction.token).toBe(validTransaction.token);
+    expect(savedTransaction.chain_id).toBe(validTransaction.chain_id);
   });
 
   it('should fail to save a Transaction without required fields', async () => {
@@ -54,7 +56,7 @@ describe('Transaction Model', () => {
       wallet_from: '0xFromWallet',
       wallet_to: '0xToWallet',
       type: 'transfer'
-      // Missing required fields: trx_hash, date, status, amount, token
+      // Missing required fields: trx_hash, date, status, amount, token, chain_id
     };
 
     const transaction = new Transaction(invalidTransaction);
@@ -71,7 +73,8 @@ describe('Transaction Model', () => {
       date: new Date(),
       status: 'completed',
       amount: 50.0,
-      token: 'ETH'
+      token: 'ETH',
+      chain_id: 1
     };
 
     const duplicateTransactionData: Partial<ITransaction> = {
@@ -82,7 +85,8 @@ describe('Transaction Model', () => {
       date: new Date(),
       status: 'pending',
       amount: 75.0,
-      token: 'BTC'
+      token: 'BTC',
+      chain_id: 1
     };
 
     const transaction1 = new Transaction(transactionData);
@@ -112,7 +116,8 @@ describe('Transaction Model', () => {
       date: new Date(),
       status: 'completed',
       amount: 1000000000.0, // Large amount
-      token: 'USDT'
+      token: 'USDT',
+      chain_id: 1
     };
 
     const transaction = new Transaction(validTransaction);


### PR DESCRIPTION
### Changes:
- Added chain_id support across the entire transaction flow — including the model, controllers (transaction and swap), services (transfer and external deposits), data types, and tests. This ensures multi-chain compatibility for all transaction-related logic.

### Details:

- [feat] ✨ add chain_id in transaction model 
- [feat] ✨ add chain_id in transaction controller 
- [feat] ✨ add chain_id in transaction model tests 
- [feat] ✨ add chain_id in transfer service 
- [feat] ✨ add chain_id in swap controller 
- [feat] ✨ add chain_id in checkExternalDeposits 
- [feat] ✨ add chain_id in mongo save transaction 
- [feat] ✨ add chain_id in external-deposit-service
- [feat] ✨ add chain_id in transactionData Type

Work in Progress
- #346