### PR TITLE
merge fix/499-transfer-receive-message-missing into develop

### DIFF
--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -23,6 +23,13 @@ import {
   CheckBalanceConditionsResult
 } from '../types/commonType';
 import {
+  openOperation,
+  closeOperation,
+  getOrCreateUser,
+  getUserWalletByChainId,
+  hasUserAnyOperationInProgress
+} from '../services/userService';
+import {
   getTokenData,
   checkBlockchainConditions,
   userReachedOperationLimit,
@@ -35,14 +42,6 @@ import {
   COMMON_REPLY_WALLET_NOT_CREATED,
   COMMON_REPLY_OPERATION_IN_PROGRESS
 } from '../config/constants';
-import {
-  openOperation,
-  closeOperation,
-  getOrCreateUser,
-  getUserWalletByChainId,
-  getUserByWalletAndChainid,
-  hasUserAnyOperationInProgress
-} from '../services/userService';
 import {
   getNotificationTemplate,
   sendInternalErrorNotification,
@@ -581,9 +580,6 @@ export const makeTransaction = async (
       executeTransactionResult.transactionHash,
       traceHeader
     );
-
-    // In case the external wallet is a ChatterPay, update the user's object
-    toUser = await getUserByWalletAndChainid(to, networkConfig.chainId);
 
     // In case the to user is a ChatterPay, send the received notification
     if (toUser) {


### PR DESCRIPTION
### Changes:

- A redundant assignment of `toUser` was using the `to` parameter, which could represent either a phone number or a wallet address. Since `toUser` had already been correctly fetched earlier in the flow, this second lookup introduced inconsistencies that prevented the recipient from receiving the transfer notification. The redundant line was removed to restore the expected behavior.  This logic was added during the task that enabled sending to external wallets.

### Closes:

- #499 

### Related to:

- #490
