### PR TITLE
merge release/20250529 into main

### DIFF
--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -23,19 +23,6 @@ import {
   CheckBalanceConditionsResult
 } from '../types/commonType';
 import {
-  getTokenData,
-  checkBlockchainConditions,
-  userReachedOperationLimit,
-  userWithinTokenOperationLimits
-} from '../services/blockchainService';
-import {
-  INFURA_URL,
-  INFURA_API_KEY,
-  GCP_CLOUD_TRACE_ENABLED,
-  COMMON_REPLY_WALLET_NOT_CREATED,
-  COMMON_REPLY_OPERATION_IN_PROGRESS
-} from '../config/constants';
-import {
   openOperation,
   closeOperation,
   getOrCreateUser,


### PR DESCRIPTION
### Changes:

- A redundant assignment of `toUser` was using the `to` parameter, which could represent either a phone number or a wallet address. Since `toUser` had already been correctly fetched earlier in the flow, this second lookup introduced inconsistencies that prevented the recipient from receiving the transfer notification. The redundant line was removed to restore the expected behavior.  This logic was added during the task that enabled sending to external wallets.

### Closes:

- #499 

### Related to:

- #490
