### PR TITLE
Fix: Deposits notification

### DIFF
--- a/src/helpers/formatHelper.ts
+++ b/src/helpers/formatHelper.ts
@@ -17,7 +17,7 @@ export function getPhoneNumberFormatted(phone: string): string {
  */
 export function formatIdentifierWithOptionalName(
   identifier: string,
-  name?: string,
+  name?: string | null,
   maskIdentifier?: boolean
 ): string {
   let formattedIdentifier = identifier;

--- a/src/services/externalDepositsService.ts
+++ b/src/services/externalDepositsService.ts
@@ -55,8 +55,8 @@ interface Transfer {
  */
 async function processExternalDeposit(transfer: Transfer, chain_id: number) {
   // First validate if the token is listed and active
-  const isTokenValid = await mongoTokenService.isValidToken(transfer.token, chain_id);
-  if (!isTokenValid) {
+  const tokenObject = await mongoTokenService.getToken(transfer.token, chain_id);
+  if (!tokenObject) {
     Logger.warn(
       'processExternalDeposit',
       `Transfer rejected: Token ${transfer.token} is not listed for chain ${chain_id}`
@@ -75,7 +75,7 @@ async function processExternalDeposit(transfer: Transfer, chain_id: number) {
   );
 
   if (user) {
-    const value = Number((Number(transfer.value) / 1e18).toFixed(4));
+    const value = Number((Number(transfer.value) / 10 ** tokenObject.decimals).toFixed(4));
 
     // Get token info
     const networkConfig = await mongoBlockchainService.getNetworkConfig();
@@ -104,9 +104,9 @@ async function processExternalDeposit(transfer: Transfer, chain_id: number) {
     try {
       // Send incoming transfer notification message, and record tx data
       await sendReceivedTransferNotification(
-        user.phone_number,
-        user.name,
         transfer.to,
+        null,
+        user.phone_number,
         value.toString(),
         tokenInfo.symbol
       );

--- a/src/services/mongo/mongoTokenService.ts
+++ b/src/services/mongo/mongoTokenService.ts
@@ -10,8 +10,7 @@ export const mongoTokenService = {
   async isValidToken(tokenAddress: string, chain_id: number): Promise<boolean> {
     const token = await Token.findOne({
       address: { $regex: new RegExp(`^${tokenAddress}$`, 'i') },
-      chain_id,
-      is_active: true
+      chain_id
     });
 
     return !!token;

--- a/src/services/mongo/mongoTokenService.ts
+++ b/src/services/mongo/mongoTokenService.ts
@@ -1,18 +1,16 @@
-import Token from '../../models/tokenModel';
+import Token, { IToken } from '../../models/tokenModel';
 
 export const mongoTokenService = {
   /**
-   * Validates if a token is listed and active in our system
-   * @param {string} tokenAddress - The token address to validate
+   * Gets a token from the database if it exists
+   * @param {string} tokenAddress - The token address to find
    * @param {number} chain_id - The chain ID where the token exists
-   * @returns {Promise<boolean>} True if the token is valid and listed
+   * @returns {Promise<Token | null>} The token object if found, null otherwise
    */
-  async isValidToken(tokenAddress: string, chain_id: number): Promise<boolean> {
-    const token = await Token.findOne({
+  async getToken(tokenAddress: string, chain_id: number): Promise<IToken | null> {
+    return Token.findOne({
       address: { $regex: new RegExp(`^${tokenAddress}$`, 'i') },
       chain_id
     });
-
-    return !!token;
   }
 };

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -118,7 +118,7 @@ export async function sendWalletCreationNotification(
  * Sends a notification for a received transfer.
  *
  * @param phoneNumberFrom - Sender's phone number.
- * @param nameFrom - Sender's name.
+ * @param nameFrom - Sender's name (optional).
  * @param phoneNumberTo - Recipient's phone number.
  * @param amount - Amount received.
  * @param token - Token symbol or identifier (e.g., ETH, USDT).
@@ -127,7 +127,7 @@ export async function sendWalletCreationNotification(
  */
 export async function sendReceivedTransferNotification(
   phoneNumberFrom: string,
-  nameFrom: string,
+  nameFrom: string | null,
   phoneNumberTo: string,
   amount: string,
   token: string,


### PR DESCRIPTION
## Description
Currently, the external deposit notification endpoint is correctly invoked and responds as expected. However, the user does not receive the corresponding WhatsApp message.

Issue: #504 

## Fixes:
- Removed is_active check in mongoTokenService (is_active did not exist on Token collection)
https://github.com/P4-Games/ChatterPay-Backend/blob/93483cd4a4ae9c1a1799941a89b6150f1257eb68/src/services/mongo/mongoTokenService.ts#L10-L15
- Updated decimals based on mongo token info
- Fixed params in user notification.

## Will be fixed on a future instance:
- Using a queue to process deposits notifications in order to avoid meta errors (Code: 131049, [Docs](https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/?locale=es_ES)
)
- Add pagination to mongo db collection, so we can support more than 1k deposits per check.  