### PR TITLE
merge feature/506-persists-user-notifications into develop

### DIFF
--- a/src/models/notificationModel.ts
+++ b/src/models/notificationModel.ts
@@ -1,0 +1,35 @@
+import { model, Schema, Document } from 'mongoose';
+
+export type NotificationMedia = 'INTERNAL' | 'PUSH' | 'WHATSAPP';
+
+export interface INotification extends Document {
+  to: string;
+  message: string;
+  media: NotificationMedia;
+  template: string;
+  sent_date: Date;
+  read_date?: Date;
+  deleted_date?: Date;
+}
+
+const NotificationSchema = new Schema<INotification>({
+  to: { type: String, required: true },
+  message: { type: String, required: true },
+  media: {
+    type: String,
+    enum: ['INTERNAL', 'PUSH', 'WHATSAPP'],
+    required: true
+  },
+  template: { type: String, required: true },
+  sent_date: { type: Date, required: true },
+  read_date: { type: Date, required: false, default: null },
+  deleted_date: { type: Date, required: false, default: null }
+});
+
+const NotificationModel = model<INotification>(
+  'Notifications',
+  NotificationSchema,
+  'notifications'
+);
+
+export default NotificationModel;

--- a/src/models/templateModel.ts
+++ b/src/models/templateModel.ts
@@ -7,7 +7,7 @@ export enum LanguageEnum {
 }
 
 export enum NotificationEnum {
-  transfer = 'transfer',
+  incoming_transfer = 'incoming_transfer',
   swap = 'swap',
   mint = 'mint',
   outgoing_transfer = 'outgoing_transfer',
@@ -55,7 +55,7 @@ const notificationSchema = new Schema<NotificationTemplateType>({
 
 const templateSchema = new Schema<ITemplateSchema>({
   notifications: {
-    transfer: { type: notificationSchema, required: true },
+    incoming_transfer: { type: notificationSchema, required: true },
     swap: { type: notificationSchema, required: true },
     mint: { type: notificationSchema, required: true },
     outgoing_transfer: { type: notificationSchema, required: true },

--- a/src/services/blockchainService.ts
+++ b/src/services/blockchainService.ts
@@ -428,7 +428,7 @@ export async function userWithinTokenOperationLimits(
 
     // Check if the amount is within the allowed limits
     if (amount < min || amount > max) {
-      Logger.error(
+      Logger.warn(
         'userWithinTokenOperationLimits',
         `Amount ${amount} for token ${tokenSymbol} is out of bounds. Min: ${min}, Max: ${max}`
       );

--- a/src/services/mongo/mongoNotificationServices.ts
+++ b/src/services/mongo/mongoNotificationServices.ts
@@ -1,0 +1,89 @@
+import { Logger } from '../../helpers/loggerHelper';
+import NotificationModel, { INotification } from '../../models/notificationModel';
+
+export const mongoNotificationService = {
+  /**
+   * Creates a new notification.
+   *
+   * @param {Partial<INotification>} data - Notification data.
+   * @returns {Promise<INotification>} Created notification document.
+   */
+  createNotification: async (data: Partial<INotification>): Promise<INotification> => {
+    try {
+      const notification = await NotificationModel.create(data);
+      return notification;
+    } catch (error) {
+      Logger.error('createNotification', 'Failed to create notification', (error as Error).message);
+      throw error;
+    }
+  },
+
+  /**
+   * Retrieves all notifications.
+   *
+   * @returns {Promise<INotification[]>} All notifications.
+   */
+  getAllNotifications: async (): Promise<INotification[]> => {
+    try {
+      return await NotificationModel.find().lean();
+    } catch (error) {
+      Logger.error(
+        'getAllNotifications',
+        'Failed to fetch notifications',
+        (error as Error).message
+      );
+      throw error;
+    }
+  },
+
+  /**
+   * Retrieves notifications for a specific recipient.
+   *
+   * @param {string} recipient - The 'to' field to filter notifications by.
+   * @returns {Promise<INotification[]>}
+   */
+  getNotificationsByRecipient: async (recipient: string): Promise<INotification[]> => {
+    try {
+      return await NotificationModel.find({ to: recipient }).lean();
+    } catch (error) {
+      Logger.error(
+        'getNotificationsByRecipient',
+        `Failed to fetch notifications for ${recipient}`,
+        (error as Error).message
+      );
+      throw error;
+    }
+  },
+
+  /**
+   * Marks a notification as read.
+   *
+   * @param {string} id - Notification ID.
+   */
+  markAsRead: async (id: string): Promise<void> => {
+    try {
+      await NotificationModel.updateOne({ _id: id }, { $set: { read_date: new Date() } });
+    } catch (error) {
+      Logger.error('markAsRead', `Failed to set read_date for ${id}`, (error as Error).message);
+      throw error;
+    }
+  },
+
+  /**
+   * Marks a notification as deleted.
+   *
+   * @param {string} id - Notification ID.
+   */
+  markAsDeleted: async (id: string): Promise<void> => {
+    try {
+      await NotificationModel.updateOne({ _id: id }, { $set: { deleted_date: new Date() } });
+    } catch (error) {
+      Logger.error(
+        'markAsDeleted',
+        `Failed to set deleted_date for ${id}`,
+        (error as Error).message
+      );
+      throw error;
+    }
+  }
+};

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -10,6 +10,7 @@ import { chatizaloService } from './chatizalo/chatizaloService';
 import { isValidPhoneNumber } from '../helpers/validationHelper';
 import { mongoBlockchainService } from './mongo/mongoBlockchainService';
 import { formatIdentifierWithOptionalName } from '../helpers/formatHelper';
+import { mongoNotificationService } from './mongo/mongoNotificationServices';
 import { templateEnum, mongoTemplateService } from './mongo/mongoTemplateService';
 import {
   BOT_DATA_TOKEN,
@@ -107,7 +108,18 @@ export async function sendWalletCreationNotification(
     );
     const formattedMessage = message.replace('[PREDICTED_WALLET_EOA_ADDRESS]', address_of_user);
 
-    pushService.sendPushNotificaton(title, formattedMessage, channel_user_id); // avoid await
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: channel_user_id,
+      messageBot: formattedMessage,
+      messagePush: formattedMessage,
+      template: NotificationEnum.wallet_creation,
+      sendPush: true,
+      sendBot: false, // the controller handles this!
+      title,
+      traceHeader: ''
+    };
+
+    await persistAndSendNotification(sendAndPersistParams);
   } catch (error) {
     Logger.error('sendWalletCreationNotification', error);
     throw error;
@@ -142,7 +154,7 @@ export async function sendReceivedTransferNotification(
 
     const { title, message } = await getNotificationTemplate(
       phoneNumberTo,
-      NotificationEnum.transfer
+      NotificationEnum.incoming_transfer
     );
 
     const formatMessage = (fromNumberAndName: string) =>
@@ -161,16 +173,18 @@ export async function sendReceivedTransferNotification(
     const formattedMessageBot = formatMessage(fromNumberAndName);
     const formattedMessagePush = formatMessage(fromNumberAndNameMasked);
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id: phoneNumberTo,
-      message: formattedMessageBot
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: phoneNumberTo,
+      messageBot: formattedMessageBot,
+      messagePush: formattedMessagePush,
+      template: NotificationEnum.incoming_transfer,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-
-    // Send push notification with masked phone number
-    pushService.sendPushNotificaton(title, formattedMessagePush, phoneNumberTo); // avoid await
+    const data = await persistAndSendNotification(sendAndPersistParams);
     return data;
   } catch (error) {
     Logger.error('sendReceivedTransferNotification', error);
@@ -217,14 +231,19 @@ export async function sendSwapNotification(
       .replaceAll('[EXPLORER]', networkConfig.explorer)
       .replaceAll('[TRANSACTION_HASH]', transactionHash);
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id,
-      message: formattedMessage
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: channel_user_id,
+      messageBot: formattedMessage,
+      messagePush: formattedMessage,
+      template: NotificationEnum.swap,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-    pushService.sendPushNotificaton(title, formattedMessage, channel_user_id); // avoid await
+    const data = await persistAndSendNotification(sendAndPersistParams);
+
     return data;
   } catch (error) {
     Logger.error('sendSwapNotification', error);
@@ -258,14 +277,18 @@ export async function sendMintNotification(
       .replaceAll('[ID]', id)
       .replaceAll('[NFTS_SHARE_URL]', CHATTERPAY_NFTS_SHARE_URL);
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id,
-      message: formattedMessage
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: channel_user_id,
+      messageBot: formattedMessage,
+      messagePush: formattedMessage,
+      template: NotificationEnum.mint,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-    pushService.sendPushNotificaton(title, formattedMessage, channel_user_id); // avoid await
+    const data = await persistAndSendNotification(sendAndPersistParams);
     return data;
   } catch (error) {
     Logger.error('sendMintNotification', (error as Error).message);
@@ -319,16 +342,18 @@ export async function sendOutgoingTransferNotification(
     const formattedMessageBot = formatMessage(toNumberAndName);
     const formattedMessagePush = formatMessage(toNumberAndNameMasked);
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id: phoneNumberFrom,
-      message: formattedMessageBot
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: phoneNumberFrom,
+      messageBot: formattedMessageBot,
+      messagePush: formattedMessagePush,
+      template: NotificationEnum.outgoing_transfer,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-
-    // Send push notification with masked phone number
-    pushService.sendPushNotificaton(title, formattedMessagePush, phoneNumberFrom); // avoid await
+    const data = await persistAndSendNotification(sendAndPersistParams);
     return data;
   } catch (error) {
     Logger.error('sendOutgoingTransferNotification', error);
@@ -359,14 +384,18 @@ export async function sendUserInsufficientBalanceNotification(
       NotificationEnum.user_balance_not_enough
     );
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id,
-      message
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: channel_user_id,
+      messageBot: message,
+      messagePush: message,
+      template: NotificationEnum.user_balance_not_enough,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-    pushService.sendPushNotificaton(title, message, channel_user_id); // avoid await
+    const data = await persistAndSendNotification(sendAndPersistParams);
     return data;
   } catch (error) {
     Logger.error('sendUserInsufficientBalanceNotification', error);
@@ -397,14 +426,18 @@ export async function sendNoValidBlockchainConditionsNotification(
       NotificationEnum.no_valid_blockchain_conditions
     );
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id,
-      message
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: channel_user_id,
+      messageBot: message,
+      messagePush: message,
+      template: NotificationEnum.no_valid_blockchain_conditions,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-    pushService.sendPushNotificaton(title, message, channel_user_id); // avoid await
+    const data = await persistAndSendNotification(sendAndPersistParams);
     return data;
   } catch (error) {
     Logger.error('sendNoValidBlockchainConditionsNotification', error);
@@ -449,14 +482,18 @@ export async function sendInternalErrorNotification(
       NotificationEnum.internal_error
     );
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id,
-      message
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: channel_user_id,
+      messageBot: message,
+      messagePush: message,
+      template: NotificationEnum.internal_error,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-    pushService.sendPushNotificaton(title, message, channel_user_id); // avoid await
+    const data = await persistAndSendNotification(sendAndPersistParams);
     return data;
   } catch (error) {
     Logger.error('sendInternalErrorNotification', error);
@@ -485,14 +522,18 @@ export async function sendConcurrecyOperationNotification(
       NotificationEnum.concurrent_operation
     );
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id,
-      message
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: channel_user_id,
+      messageBot: message,
+      messagePush: message,
+      template: NotificationEnum.concurrent_operation,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-    pushService.sendPushNotificaton(title, message, channel_user_id); // avoid await
+    const data = await persistAndSendNotification(sendAndPersistParams);
     return data;
   } catch (error) {
     Logger.error('SendConcurrecyOperationNotification', error);
@@ -521,14 +562,18 @@ export async function sendDailyLimitReachedNotification(
       NotificationEnum.daily_limit_reached
     );
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id,
-      message
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: channel_user_id,
+      messageBot: message,
+      messagePush: message,
+      template: NotificationEnum.daily_limit_reached,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-    pushService.sendPushNotificaton(title, message, channel_user_id); // intentionally not awaited
+    const data = await persistAndSendNotification(sendAndPersistParams);
     return data;
   } catch (error) {
     Logger.error('sendDailyLimitReachedNotification', error);
@@ -567,17 +612,129 @@ export async function sendOperationOutsideLimitsNotification(
       .replace('[LIMIT_MIN]', minLimit.toString())
       .replace('[LIMIT_MAX]', maxLimit.toString());
 
-    const payload: chatizaloOperatorReply = {
-      data_token: BOT_DATA_TOKEN!,
-      channel_user_id,
-      message: formattedMessage
+    const sendAndPersistParams: SendAndPersistParams = {
+      to: channel_user_id,
+      messageBot: formattedMessage,
+      messagePush: formattedMessage,
+      template: NotificationEnum.amount_outside_limits,
+      sendPush: true,
+      sendBot: true,
+      title,
+      traceHeader
     };
 
-    const data = await chatizaloService.sendBotNotification(payload, traceHeader);
-    pushService.sendPushNotificaton(title, formattedMessage, channel_user_id); // intentionally not awaited
+    const data = await persistAndSendNotification(sendAndPersistParams);
     return data;
   } catch (error) {
     Logger.error('sendOperationOutsideLimitsNotification', error);
     throw error;
+  }
+}
+
+/* ----------------------------------------------------------------------------------------- */
+/* ----------------------------------------------------------------------------------------- */
+
+interface SendAndPersistParams {
+  to: string;
+  messageBot: string;
+  messagePush: string;
+  template: string;
+  sendPush?: boolean;
+  sendBot?: boolean;
+  title?: string; // solo para push
+  traceHeader?: string;
+}
+
+/**
+ * Persists a notification in MongoDB (always with media: 'INTERNAL'),
+ * then optionally sends it via WhatsApp (bot) and/or Push.
+ *
+ * @param {string} to - Recipient identifier (e.g., phone number).
+ * @param {string} messageBot - Message content to be sent and stored.
+ * @param {string} messagePush - Message content to be sent and stored.
+ * @param {string} template - Template identifier used for the notification.
+ * @param {boolean} [sendPush=false] - Whether to send the notification via Push.
+ * @param {boolean} [sendBot=false] - Whether to send the notification via WhatsApp bot.
+ * @param {string} [title] - Title for the Push notification (required if sendPush is true).
+ * @param {string} [traceHeader] - Optional trace header for observability.
+ *
+ * @returns {Promise<string | null>} The bot service response if sent via WhatsApp, otherwise null.
+ */
+export async function persistAndSendNotification({
+  to,
+  messageBot,
+  messagePush,
+  template,
+  sendPush = false,
+  sendBot = false,
+  title,
+  traceHeader
+}: SendAndPersistParams): Promise<string | null> {
+  const sent_date = new Date();
+
+  try {
+    let data: string | null = null;
+
+    // 1. Persist always with media INTERNAL
+    await mongoNotificationService.createNotification({
+      to,
+      message: messageBot,
+      template,
+      media: 'INTERNAL',
+      sent_date,
+      read_date: undefined,
+      deleted_date: undefined
+    });
+
+    // 2. Send via Chatizalo if flag is true
+    if (sendBot) {
+      const payload: chatizaloOperatorReply = {
+        data_token: BOT_DATA_TOKEN!,
+        channel_user_id: to,
+        message: messageBot
+      };
+      data = await chatizaloService.sendBotNotification(payload, traceHeader);
+    }
+
+    // 3. Send via PUSH if flag is true
+    if (sendPush && title) {
+      pushService.sendPushNotificaton(title, messagePush, to); // fire & forget (avoid await)
+    }
+
+    return data;
+  } catch (error) {
+    Logger.error('sendAndPersistNotification', error);
+    throw error;
+  }
+}
+
+/**
+ * Persists a notification in MongoDB with media: 'INTERNAL',
+ * without sending it via bot or push.
+ *
+ * @param {string} to - Recipient identifier (e.g., phone number).
+ * @param {string} message - Message content to store.
+ * @param {string} template - Template identifier.
+ * @returns {Promise<void>}
+ */
+export async function persistNotification(
+  to: string,
+  message: string,
+  template: string
+): Promise<void> {
+  const sent_date = new Date();
+
+  try {
+    await mongoNotificationService.createNotification({
+      to,
+      message,
+      template,
+      media: 'INTERNAL',
+      sent_date,
+      read_date: undefined,
+      deleted_date: undefined
+    });
+  } catch (error) {
+    Logger.error('persistNotification', error);
   }
 }

--- a/test/models/templateModel.test.ts
+++ b/test/models/templateModel.test.ts
@@ -30,7 +30,7 @@ describe('Template Model', () => {
 
     const validTemplate: TestTemplateSchema = {
       notifications: {
-        transfer: {
+        incoming_transfer: {
           title: {
             en: 'Transfer completed',
             es: 'Transferencia completada',
@@ -149,7 +149,7 @@ describe('Template Model', () => {
     const savedTemplate = await template.save();
 
     expect(savedTemplate._id).toBeDefined();
-    expect(savedTemplate.notifications.transfer.title.en).toBe('Transfer completed');
+    expect(savedTemplate.notifications.incoming_transfer.title.en).toBe('Transfer completed');
   });
 
   it('should fail to save without required fields', async () => {
@@ -163,7 +163,7 @@ describe('Template Model', () => {
 
     const invalidTemplate = {
       notifications: {
-        transfer: {
+        incoming_transfer: {
           title: {
             en: 'Transfer completed',
             es: 'Transferencia completada',


### PR DESCRIPTION
### Changes:

The backend was updated to persist all user notifications after they are sent. This allows us to optionally display a notification history in the frontend and improve support and debugging for delivery or transaction issues. Each record stores the user ID, message text, timestamp, and delivery channel (bot or push). The message delivery flow itself was not modified.

### Closes:

- #506