### PR TITLE
merge fix/disabled-user-signer-check-balance into develop

### DIFF
--- a/src/services/blockchainService.ts
+++ b/src/services/blockchainService.ts
@@ -246,6 +246,7 @@ export async function checkBlockchainConditions(
       );
     }
 
+    /*
     const userWalletAddress = await setupContractsResult.signer.getAddress();
     const checkUserEthBalanceResult = await ensureUserSignerHasEnoughEth(
       networkConfig.balances,
@@ -258,6 +259,7 @@ export async function checkBlockchainConditions(
         `User Wallet ${setupContractsResult.proxy.proxyAddress}, insufficient ETH balance.`
       );
     }
+    */
 
     const entrypointABI = await getEntryPointABI();
     const entrypointContract = new ethers.Contract(


### PR DESCRIPTION
### Changes:

- Commented out the redundant logic that was transferring ETH from the backend signer to the user's EOA. Since the user did not need ETH to perform operations when using a Paymaster, these transfers were unnecessary and had caused unintended losses. Removing this step ensured better fund management without affecting functionality.

### Closes:

- #517