### PR TITLE
[fix] :bug: wrong user in received notification (#520)

### DIFF
--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -506,7 +506,7 @@ export const makeTransaction = async (
     } else {
       const chatterpayProxyAddress: string = networkConfig.contracts.chatterPayAddress;
       const { factoryAddress } = networkConfig.contracts;
-      toUser = await getOrCreateUser(channel_user_id, chatterpayProxyAddress, factoryAddress);
+      toUser = await getOrCreateUser(to, chatterpayProxyAddress, factoryAddress);
       toAddress = toUser.wallets[0].wallet_proxy;
     }
     userCreationSpan?.endSpan();


### PR DESCRIPTION
### Changes:

- During the implementation of Task #520 (Avoid Redundant Proxy Computation), an error was introduced where, after a transfer, the notification indicating the received amount was mistakenly sent to the sender instead of the intended recipient.

### Related to:

- #520