### PR TITLE
merge feat/remove-autogen-id-in-wallets-sub-docs into develop

### DIFF
--- a/src/models/userModel.ts
+++ b/src/models/userModel.ts
@@ -43,23 +43,26 @@ export interface IUser extends Document {
   manteca_user_id?: string;
 }
 
-const walletSchema = new Schema<IUserWallet>({
-  wallet_proxy: { type: String, required: true, default: '' },
-  wallet_eoa: { type: String, required: true, default: '' },
-  sk_hashed: { type: String, required: true, default: '' },
-  created_with_chatterpay_proxy_address: {
-    type: String,
-    required: false,
-    default: ''
+const walletSchema = new Schema<IUserWallet>(
+  {
+    wallet_proxy: { type: String, required: true, default: '' },
+    wallet_eoa: { type: String, required: true, default: '' },
+    sk_hashed: { type: String, required: true, default: '' },
+    created_with_chatterpay_proxy_address: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    created_with_factory_address: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    chain_id: { type: Number, required: true, default: DEFAULT_CHAIN_ID },
+    status: { type: String, required: true, default: 'active' }
   },
-  created_with_factory_address: {
-    type: String,
-    required: false,
-    default: ''
-  },
-  chain_id: { type: Number, required: true, default: DEFAULT_CHAIN_ID },
-  status: { type: String, required: true, default: 'active' }
-});
+  { _id: false }
+);
 
 const userSchema = new Schema<IUser>({
   name: { type: String, required: false },


### PR DESCRIPTION
### Changes:

- Mongoose was creating an _id field for each wallet subdocument inside the wallets array by default. Since these IDs were not used and added unnecessary clutter to the documents, the schema was updated to explicitly disable _id generation for wallet entries.

### Closes:

- #525 