### PR TITLE
[refactor] :recycle: add detailed logging to wraRpc (#536)

### DIFF
--- a/src/services/web3/userOperationService.ts
+++ b/src/services/web3/userOperationService.ts
@@ -265,15 +265,19 @@ export async function waitForUserOperationReceipt(
       Logger.log('waitForUserOperationReceipt', `payload: ${JSON.stringify(payload)}`);
 
       try {
-        const response = (await wrapRpc(
-          async () =>
-            axios.post(bundlerRpcUrl, payload, {
-              headers: {
-                'Content-Type': 'application/json'
-              }
-            }),
+        const response = await wrapRpc<AxiosResponse>(
+          {
+            fn: async () =>
+              axios.post(bundlerRpcUrl, payload, {
+                headers: {
+                  'Content-Type': 'application/json'
+                }
+              }),
+            name: 'axios.post',
+            args: [bundlerRpcUrl, payload]
+          },
           rpcProviders.PIMLICO
-        )) as AxiosResponse;
+        );
 
         const receipt = response.data.result;
 


### PR DESCRIPTION
### Changes:

- Improved the `wrapRpc` utility by adding detailed logging for better traceability. The log now includes the queue type, estimated position in the queue, function name, and serialized arguments. This enhancement helps track which RPC calls are queued and when, especially useful under high concurrency scenarios.

### Related with:

- #536 
