### PR TITLE
merge feature/547-refactor-cache-layer into develop

### DIFF
--- a/src/api/supportRoutes.ts
+++ b/src/api/supportRoutes.ts
@@ -1,6 +1,8 @@
 import { FastifyInstance } from 'fastify';
 
 import {
+  clearAllCaches,
+  clearCacheByName,
   resetUsersOperations,
   resetUsersOperationLimits,
   checkUsersWithOpenOperations,
@@ -83,6 +85,40 @@ const supportRoutes = async (fastify: FastifyInstance): Promise<void> => {
    * @returns {Object} Confirmation message of successful reset.
    */
   fastify.put('/support/reset_user_operations_counters', resetUsersOperationLimits);
+
+  /**
+   * Route to clear all application-level caches.
+   * Useful for maintenance or during testing to force cache repopulation.
+   *
+   * @route POST /support/clear_all_caches
+   * @returns {Object} Success message
+   * @example
+   * {
+   *   "success": true,
+   *   "message": "All caches have been cleared."
+   * }
+   */
+  fastify.post('/support/clear_all_caches', clearAllCaches);
+
+  /**
+   * Route to clear a specific named cache.
+   *
+   * @route POST /support/clear_cache_by_name
+   * @bodyParam {string} cacheName - The name of the cache to clear. Must be one of the CacheNames enum values.
+   * @returns {Object} Success or error message
+   * @example
+   * // Request body:
+   * {
+   *   "cacheName": "priceCache"
+   * }
+   *
+   * // Response:
+   * {
+   *   "success": true,
+   *   "message": "Cache \"priceCache\" has been cleared."
+   * }
+   */
+  fastify.post('/support/clear_cache_by_name', clearCacheByName);
 };
 
 export default supportRoutes;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -130,7 +130,6 @@ export const CURRENT_LOG_LEVEL: LogLevel = validLogLevels.includes(
 export const validLanguages: Array<'en' | 'es' | 'pt'> = ['en', 'es', 'pt'];
 export const SETTINGS_NOTIFICATION_LANGUAGE_DFAULT: string = 'en';
 
-export const NOTIFICATION_TEMPLATE_CACHE_TTL = 60800; // 1 week
 export const RESET_USER_OPERATION_THRESHOLD_MINUTES = 30;
 export const GCP_CLOUD_TRACE_ENABLED: boolean = gcpCloudTraceEnabled.toLowerCase() === 'true';
 
@@ -171,3 +170,21 @@ export const QUEUE_BUNDLER_INTERVAL = Number(queueBundlerInterval);
 export const QUEUE_GAS_INTERVAL = Number(queueGasInterval);
 export const QUEUE_CREATE_PROXY_INTERVAL = Number(queueCreateProxyInterval);
 export const MAX_REQUESTS_PER_MINUTE = Number(maxRequestsPerMinute);
+
+export const CACHE_OPENSEA_TTL = 300; // 5 min
+export const CACHE_OPENSEA_CHECK_PERIOD = 600; // 10 min
+
+export const CACHE_PRICE_TTL = 300; // 5 min
+export const CACHE_PRICE_CHECK_PERIOD = 360; // 6 min
+
+export const CACHE_ABI_TTL = 432000; // 5 days
+export const CACHE_ABI_CHECK_PERIOD = 518400; // 6 days
+
+export const CACHE_NOTIFICATION_TTL = 432000; // 5 days
+export const CACHE_NOTIFICATION_CHECK_PERIOD = 518400; // 6 days
+
+export const CACHE_TOR_TTL = 3600; // 1 hora
+export const CACHE_TOR_CHECK_PERIOD = 3700; // 62 min
+
+export const CACHE_COINGECKO_TTL = 60; // 1 min
+export const CACHE_COINGECKO_CHECK_PERIOD = 120; // 2 min

--- a/src/services/cache/cacheService.ts
+++ b/src/services/cache/cacheService.ts
@@ -1,0 +1,78 @@
+import NodeCache from 'node-cache';
+
+import { CacheNames } from '../../types/commonType';
+import {
+  CACHE_ABI_TTL,
+  CACHE_TOR_TTL,
+  CACHE_PRICE_TTL,
+  CACHE_OPENSEA_TTL,
+  CACHE_COINGECKO_TTL,
+  CACHE_ABI_CHECK_PERIOD,
+  CACHE_NOTIFICATION_TTL,
+  CACHE_TOR_CHECK_PERIOD,
+  CACHE_PRICE_CHECK_PERIOD,
+  CACHE_OPENSEA_CHECK_PERIOD,
+  CACHE_COINGECKO_CHECK_PERIOD,
+  CACHE_NOTIFICATION_CHECK_PERIOD
+} from '../../config/constants';
+
+/**
+ * TTL and checkperiod configurations (in seconds).
+ */
+const TTL_CONFIG = {
+  [CacheNames.OPENSEA]: { stdTTL: CACHE_OPENSEA_TTL, checkperiod: CACHE_OPENSEA_CHECK_PERIOD },
+  [CacheNames.PRICE]: { stdTTL: CACHE_PRICE_TTL, checkperiod: CACHE_PRICE_CHECK_PERIOD },
+  [CacheNames.ABI]: { stdTTL: CACHE_ABI_TTL, checkperiod: CACHE_ABI_CHECK_PERIOD },
+  [CacheNames.NOTIFICATION]: {
+    stdTTL: CACHE_NOTIFICATION_TTL,
+    checkperiod: CACHE_NOTIFICATION_CHECK_PERIOD
+  },
+  [CacheNames.TOR]: { stdTTL: CACHE_TOR_TTL, checkperiod: CACHE_TOR_CHECK_PERIOD },
+  [CacheNames.COINGECKO]: { stdTTL: CACHE_COINGECKO_TTL, checkperiod: CACHE_COINGECKO_CHECK_PERIOD }
+};
+
+/**
+ * Initialize NodeCache instances per cache category.
+ */
+const caches: Record<CacheNames, NodeCache> = {
+  [CacheNames.OPENSEA]: new NodeCache(TTL_CONFIG[CacheNames.OPENSEA]),
+  [CacheNames.PRICE]: new NodeCache(TTL_CONFIG[CacheNames.PRICE]),
+  [CacheNames.ABI]: new NodeCache(TTL_CONFIG[CacheNames.ABI]),
+  [CacheNames.NOTIFICATION]: new NodeCache(TTL_CONFIG[CacheNames.NOTIFICATION]),
+  [CacheNames.TOR]: new NodeCache(TTL_CONFIG[CacheNames.TOR]),
+  [CacheNames.COINGECKO]: new NodeCache(TTL_CONFIG[CacheNames.COINGECKO])
+};
+
+/**
+ * Centralized cache service for getting/setting/clearing data across all cache types.
+ */
+export const cacheService = {
+  get: <T>(cacheName: CacheNames, key: string): T | undefined => caches[cacheName]?.get<T>(key),
+
+  set: <T>(cacheName: CacheNames, key: string, value: T, ttl?: number): void => {
+    if (ttl !== undefined) {
+      caches[cacheName].set<T>(key, value, ttl);
+    } else {
+      caches[cacheName].set<T>(key, value);
+    }
+  },
+
+  remove: (cacheName: CacheNames, key: string): void => {
+    caches[cacheName]?.del(key);
+  },
+
+  has: (cacheName: CacheNames, key: string): boolean => caches[cacheName]?.has(key) ?? false,
+
+  keys: (cacheName: CacheNames): string[] => caches[cacheName]?.keys() ?? [],
+
+  clearCache: (cacheName: CacheNames): void => {
+    caches[cacheName]?.flushAll();
+  },
+
+  clearAllCaches: (): void => {
+    Object.values(caches).forEach((cache) => cache.flushAll());
+  },
+
+  isValidCacheName: (name: string): name is CacheNames =>
+    Object.values(CacheNames).includes(name as CacheNames)
+};

--- a/src/services/coingecko/coingeckoService.ts
+++ b/src/services/coingecko/coingeckoService.ts
@@ -1,12 +1,9 @@
 import axios from 'axios';
-import NodeCache from 'node-cache';
 
 import { Logger } from '../../helpers/loggerHelper';
-import { ConversionRates } from '../../types/commonType';
+import { cacheService } from '../cache/cacheService';
+import { CacheNames, ConversionRates } from '../../types/commonType';
 import { TOKEN_IDS, RESULT_CURRENCIES, COINGECKO_API_BASE_URL } from '../../config/constants';
-
-// Initialize the cache
-const cache = new NodeCache({ stdTTL: 60, checkperiod: 120 });
 
 /**
  * Generates a fallback response with zero values for all tokens and currencies.
@@ -56,14 +53,14 @@ export const coingeckoService = {
    */
   getConversationRates: async (): Promise<ConversionRates> => {
     const cacheKey = `getConversationRates`;
-    const fromCache = cache.get(cacheKey);
+    const fromCache = cacheService.get(CacheNames.COINGECKO, cacheKey);
 
     if (fromCache) {
       return fromCache as ConversionRates;
     }
 
     const result = await getCoingeckoConversionRates();
-    cache.set(cacheKey, result);
+    cacheService.set(CacheNames.COINGECKO, cacheKey, result);
     return result;
   },
 
@@ -74,7 +71,7 @@ export const coingeckoService = {
    */
   getTokenPrice: async (tokenId: string): Promise<number> => {
     const cacheKey = `token_${tokenId}`;
-    const fromCache = cache.get(cacheKey);
+    const fromCache = cacheService.get(CacheNames.COINGECKO, cacheKey);
 
     if (fromCache) {
       return fromCache as number;
@@ -83,7 +80,7 @@ export const coingeckoService = {
     const result = await getCoingeckoTokenData(tokenId);
     if (result?.[tokenId]?.usd) {
       const price = result[tokenId].usd;
-      cache.set(cacheKey, price);
+      cacheService.set(CacheNames.COINGECKO, cacheKey, price);
       return price;
     }
     return 0;

--- a/src/types/commonType.ts
+++ b/src/types/commonType.ts
@@ -130,3 +130,12 @@ export const rpcProviders = {
 } as const;
 
 export type RpcProvider = (typeof rpcProviders)[keyof typeof rpcProviders];
+
+export enum CacheNames {
+  OPENSEA = 'openSea',
+  PRICE = 'priceCache',
+  ABI = 'abiCache',
+  NOTIFICATION = 'notificationTemplateCache',
+  TOR = 'torCache',
+  COINGECKO = 'coingeckoCache'
+}


### PR DESCRIPTION
### Changes:

- Centralized all cache usage across the codebase by introducing a shared `cacheService` with named cache instances and unified TTL management. Replaced multiple scattered `NodeCache` instantiations in services and controllers with a consistent API, improving maintainability, testability, and cache visibility. Added support endpoints to clear all caches or a specific cache by name. This change simplifies future upgrades (e.g. Redis) and enforces consistent caching behavior across modules.

### Closes:

- #547