### PR TITLE
merge fix/562-563-external-deposits into develop

### DIFF
--- a/src/services/externalDepositsService.ts
+++ b/src/services/externalDepositsService.ts
@@ -1,3 +1,4 @@
+import { getAddress } from 'ethers/lib/utils';
 import { gql, request } from 'graphql-request';
 
 import { UserModel } from '../models/userModel';
@@ -115,8 +116,8 @@ async function processExternalDeposit(
 
       const transactionData: TransactionData = {
         tx: txHash,
-        walletFrom: transfer.from,
-        walletTo: transfer.to,
+        walletFrom: getAddress(transfer.from),
+        walletTo: getAddress(transfer.to),
         amount: value,
         fee: 0,
         token: tokenInfo.symbol,

--- a/src/services/externalDepositsService.ts
+++ b/src/services/externalDepositsService.ts
@@ -108,8 +108,13 @@ async function processExternalDeposit(
       }
 
       Logger.debug('processExternalDeposit', 'Saving external deposit transaction in database.');
+
+      // Some subgraphs use `id` as a composite of `txHash + logIndex`.
+      // We extract only the first 66 characters to get the actual transaction hash (0x + 64 hex digits).
+      const txHash = transfer.id.slice(0, 66);
+
       const transactionData: TransactionData = {
-        tx: transfer.id,
+        tx: txHash,
         walletFrom: transfer.from,
         walletTo: transfer.to,
         amount: value,
@@ -132,7 +137,7 @@ async function processExternalDeposit(
         );
         Logger.debug(
           'processExternalDeposit',
-          `Notification sent successfully for transfer ${transfer.id} to user ${user.phone_number}`
+          `Notification sent successfully for transfer ${txHash} to user ${user.phone_number}`
         );
       }
     } else {


### PR DESCRIPTION
### Changes:
- Fixed an issue where transaction hashes from external deposits were being saved with extra trailing characters, resulting in 74-character strings. The hash is now correctly sliced to 66 characters before being persisted.
- Normalized all wallet addresses stored as `walletFrom` and `walletTo` using EIP-55 checksum casing. This ensures consistent formatting and avoids issues related to lowercase-only addresses.


### Closes:

- #562 
- #563 

