### PR TITLE
merge Feature/577-transfer-user-notes into develop

### DIFF
--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -602,6 +602,7 @@ export const makeTransaction = async (
       toUser?.name ?? '',
       amount,
       tokenData!.symbol,
+      santizedUserNotes,
       executeTransactionResult.transactionHash,
       traceHeader
     );
@@ -614,6 +615,7 @@ export const makeTransaction = async (
         toUser.phone_number,
         amountAfterFee.toString(),
         tokenData!.symbol,
+        santizedUserNotes,
         traceHeader
       );
     }

--- a/src/models/transactionModel.ts
+++ b/src/models/transactionModel.ts
@@ -11,6 +11,7 @@ export interface ITransaction extends Document {
   fee: number;
   token: string;
   chain_id: number;
+  user_notes: string;
 }
 
 const transactionSchema = new Schema<ITransaction>({
@@ -23,7 +24,8 @@ const transactionSchema = new Schema<ITransaction>({
   amount: { type: Number, required: true },
   fee: { type: Number, required: true },
   token: { type: String, required: true },
-  chain_id: { type: Number, required: true }
+  chain_id: { type: Number, required: true },
+  user_notes: { type: String, required: false }
 });
 
 transactionSchema.index(

--- a/src/services/externalDepositsService.ts
+++ b/src/services/externalDepositsService.ts
@@ -134,6 +134,7 @@ async function processExternalDeposit(
           null,
           user.phone_number,
           value.toString(),
+          '',
           tokenInfo.symbol
         );
         Logger.debug(

--- a/src/services/mongo/mongoTransactionService.ts
+++ b/src/services/mongo/mongoTransactionService.ts
@@ -8,8 +8,19 @@ export const mongoTransactionService = {
    */
   saveTransaction: async (transactionData: TransactionData) => {
     try {
-      const { tx, walletFrom, walletTo, amount, fee, token, type, status, chain_id, date } =
-        transactionData;
+      const {
+        tx,
+        walletFrom,
+        walletTo,
+        amount,
+        fee,
+        token,
+        type,
+        status,
+        chain_id,
+        date,
+        user_notes
+      } = transactionData;
 
       await Transaction.create({
         trx_hash: tx,
@@ -21,7 +32,8 @@ export const mongoTransactionService = {
         amount,
         fee,
         token,
-        chain_id
+        chain_id,
+        user_notes: user_notes || ''
       });
     } catch (error: unknown) {
       // avoid throw error

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -183,6 +183,7 @@ export async function sendWalletAlreadyExistsNotification(
  * @param phoneNumberTo - Recipient's phone number.
  * @param amount - Amount received.
  * @param token - Token symbol or identifier (e.g., ETH, USDT).
+ * @param user_notes - User notes associated with the transaction.
  * @param traceHeader - (Optional) Trace identifier for debugging or logging purposes.
  * @returns A Promise resolving to the result of the notification operation.
  */
@@ -192,6 +193,7 @@ export async function sendReceivedTransferNotification(
   phoneNumberTo: string,
   amount: string,
   token: string,
+  user_notes: string,
   traceHeader?: string
 ): Promise<unknown> {
   try {
@@ -210,7 +212,8 @@ export async function sendReceivedTransferNotification(
       message
         .replaceAll('[FROM]', fromNumberAndName)
         .replaceAll('[AMOUNT]', amount)
-        .replaceAll('[TOKEN]', token);
+        .replaceAll('[TOKEN]', token)
+        .replaceAll('[USER_NOTES]', user_notes ? `\n('${user_notes}')` : '');
 
     const fromNumberAndName = formatIdentifierWithOptionalName(phoneNumberFrom, nameFrom, false);
     const fromNumberAndNameMasked = formatIdentifierWithOptionalName(
@@ -353,6 +356,7 @@ export async function sendMintNotification(
  * @param toName - Recipient's name.
  * @param amount - Amount transferred.
  * @param token - Token symbol or identifier (e.g., ETH, USDT).
+ * @param user_notes - User notes associated with the transaction.
  * @param txHash - Blockchain transaction hash of the transfer.
  * @param traceHeader - (Optional) Trace identifier for debugging or logging purposes.
  * @returns A Promise resolving to the result of the notification operation.
@@ -363,6 +367,7 @@ export async function sendOutgoingTransferNotification(
   toName: string,
   amount: string,
   token: string,
+  user_notes: string,
   txHash: string,
   traceHeader?: string
 ): Promise<unknown> {
@@ -383,7 +388,8 @@ export async function sendOutgoingTransferNotification(
         .replaceAll('[TOKEN]', token)
         .replaceAll('[TO]', toNumberAndName)
         .replaceAll('[EXPLORER]', networkConfig.explorer)
-        .replaceAll('[TX_HASH]', txHash);
+        .replaceAll('[TX_HASH]', txHash)
+        .replaceAll('[USER_NOTES]', user_notes ? `\n('${user_notes}')` : '');
 
     const toNumberAndName = formatIdentifierWithOptionalName(phoneNumberTo, toName, false);
     const toNumberAndNameMasked = formatIdentifierWithOptionalName(phoneNumberTo, toName, true);

--- a/src/types/commonType.ts
+++ b/src/types/commonType.ts
@@ -103,6 +103,7 @@ export interface TransactionData {
   status: string;
   chain_id: number;
   date?: Date;
+  user_notes?: string;
 }
 
 export interface ConversionRates {

--- a/test/models/transactionModel.test.ts
+++ b/test/models/transactionModel.test.ts
@@ -34,7 +34,8 @@ describe('Transaction Model', () => {
       amount: 100.5,
       fee: 0.5,
       token: 'ETH',
-      chain_id: 1
+      chain_id: 1,
+      user_notes: 'Test transaction'
     };
 
     const transaction = new Transaction(validTransaction);
@@ -76,7 +77,8 @@ describe('Transaction Model', () => {
       amount: 50.0,
       fee: 0.5,
       token: 'ETH',
-      chain_id: 1
+      chain_id: 1,
+      user_notes: 'Test transaction'
     };
 
     const duplicateTransactionData: Partial<ITransaction> = {
@@ -89,7 +91,8 @@ describe('Transaction Model', () => {
       amount: 75.0,
       fee: 0.5,
       token: 'BTC',
-      chain_id: 1
+      chain_id: 1,
+      user_notes: 'Test transaction'
     };
 
     const transaction1 = new Transaction(transactionData);
@@ -121,7 +124,8 @@ describe('Transaction Model', () => {
       amount: 1000000000.0, // Large amount
       fee: 0.5,
       token: 'USDT',
-      chain_id: 1
+      chain_id: 1,
+      user_notes: 'Test transaction'
     };
 
     const transaction = new Transaction(validTransaction);


### PR DESCRIPTION
### Changes:

- Added support for **optional user notes on transfers**. Users can now add a short personal message when sending funds. The note is stored in the transaction record, included in notifications (incoming and outgoing), and available through the API. If no note is provided, the flow and templates remain unchanged. This enhancement improves the transfer experience by allowing senders to add context or a personal touch to their transactions.

### Related To:

- #577