### PR TITLE
merge release/20250830 into main

### DIFF
--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -60,6 +60,7 @@ type MakeTransactionInputs = {
   token: string;
   amount: string;
   chain_id?: string;
+  user_notes?: string;
 };
 
 /**
@@ -270,6 +271,60 @@ export const deleteTransaction = async (
 };
 
 /**
+ * Sanitize user notes for WhatsApp text channels.
+ * - Allows: letters (all langs), marks, numbers, punctuation, symbols (incl. emojis), spaces/newlines.
+ * - Removes: controls, surrogates, most invisibles (keeps ZWJ U+200D and VS16 U+FE0F for emoji ligatures).
+ * - Optional: preserve WhatsApp formatting (* _ ~), strip backticks to avoid code formatting.
+ * - Normalizes (NFKC), collapses whitespace, caps length.
+ */
+export function sanitizeUserNotesWhatsApp(
+  input: string,
+  options: { maxLen?: number; preserveWaFormatting?: boolean } = {}
+): string {
+  const { maxLen = 500, preserveWaFormatting = true } = options;
+  if (!input) return '';
+
+  // 1) Normalize
+  let s = input.normalize('NFKC');
+
+  // 2) Remove control (Cc) and surrogate (Cs) chars
+  s = s.replace(/[\p{Cc}\p{Cs}]/gu, '');
+
+  // 3) Remove most format (Cf) except ZWJ (200D) and VS16 (FE0F)
+  s = Array.from(s)
+    .filter((ch) => {
+      const cp = ch.codePointAt(0)!;
+      if (/\p{Cf}/u.test(ch)) return cp === 0x200d || cp === 0xfe0f;
+      return true;
+    })
+    .join('');
+
+  // 4) Keep only L/M/N/P/Z/S categories (covers letters, digits, punctuation, symbols/emojis, spaces)
+  s = s.replace(/[^\p{L}\p{M}\p{N}\p{P}\p{Z}\p{S}]/gu, '');
+
+  // 5) WhatsApp formatting policy
+  if (preserveWaFormatting) {
+    // Strip backticks to avoid code formatting (inline or triple)
+    s = s.replace(/`+/g, '');
+    // Keep *, _, ~ as-is for WA formatting
+  } else {
+    // Remove all formatting markers
+    s = s.replace(/[*_~`]+/g, '');
+  }
+
+  // 6) Normalize line breaks & collapse whitespace
+  s = s.replace(/\r\n?/g, '\n'); // CRLF/CR -> LF
+  s = s.replace(/[ \t\f\v]+/g, ' '); // collapse spaces/tabs
+  s = s.replace(/\n{3,}/g, '\n\n'); // max two consecutive newlines
+  s = s.trim();
+
+  // 7) Length guard
+  if (s.length > maxLen) s = s.slice(0, maxLen);
+
+  return s;
+}
+
+/**
  * Handles the make transaction request.
  *
  * @param request
@@ -305,9 +360,13 @@ export const makeTransaction = async (
       return await returnErrorResponse(reply, 400, 'You have to send a body with this request');
     }
 
-    const { channel_user_id, to, token: tokenSymbol, amount } = request.body;
+    const { channel_user_id, to, token: tokenSymbol, amount, user_notes } = request.body;
     const lastBotMsgDelaySeconds = request.query?.lastBotMsgDelaySeconds || 0;
     const { networkConfig, tokens: tokensConfig } = request.server as FastifyInstance;
+    const santizedUserNotes = sanitizeUserNotesWhatsApp(user_notes || '', {
+      maxLen: 500,
+      preserveWaFormatting: true
+    });
 
     const tokenData: IToken | undefined = getTokenData(
       networkConfig,
@@ -568,7 +627,8 @@ export const makeTransaction = async (
       token: tokenSymbol,
       type: 'transfer',
       status: 'completed',
-      chain_id: request.server.networkConfig.chainId
+      chain_id: request.server.networkConfig.chainId,
+      user_notes: santizedUserNotes
     };
     await mongoTransactionService.saveTransaction(transactionOut);
     saveTransactionSpan?.endSpan();
@@ -602,6 +662,7 @@ export const makeTransaction = async (
       toUser?.name ?? '',
       amount,
       tokenData!.symbol,
+      santizedUserNotes,
       executeTransactionResult.transactionHash,
       traceHeader
     );
@@ -614,6 +675,7 @@ export const makeTransaction = async (
         toUser.phone_number,
         amountAfterFee.toString(),
         tokenData!.symbol,
+        santizedUserNotes,
         traceHeader
       );
     }

--- a/src/models/transactionModel.ts
+++ b/src/models/transactionModel.ts
@@ -11,6 +11,7 @@ export interface ITransaction extends Document {
   fee: number;
   token: string;
   chain_id: number;
+  user_notes: string;
 }
 
 const transactionSchema = new Schema<ITransaction>({
@@ -23,7 +24,8 @@ const transactionSchema = new Schema<ITransaction>({
   amount: { type: Number, required: true },
   fee: { type: Number, required: true },
   token: { type: String, required: true },
-  chain_id: { type: Number, required: true }
+  chain_id: { type: Number, required: true },
+  user_notes: { type: String, required: false }
 });
 
 transactionSchema.index(

--- a/src/services/externalDepositsService.ts
+++ b/src/services/externalDepositsService.ts
@@ -134,6 +134,7 @@ async function processExternalDeposit(
           null,
           user.phone_number,
           value.toString(),
+          '',
           tokenInfo.symbol
         );
         Logger.debug(

--- a/src/services/mongo/mongoTransactionService.ts
+++ b/src/services/mongo/mongoTransactionService.ts
@@ -8,8 +8,19 @@ export const mongoTransactionService = {
    */
   saveTransaction: async (transactionData: TransactionData) => {
     try {
-      const { tx, walletFrom, walletTo, amount, fee, token, type, status, chain_id, date } =
-        transactionData;
+      const {
+        tx,
+        walletFrom,
+        walletTo,
+        amount,
+        fee,
+        token,
+        type,
+        status,
+        chain_id,
+        date,
+        user_notes
+      } = transactionData;
 
       await Transaction.create({
         trx_hash: tx,
@@ -21,7 +32,8 @@ export const mongoTransactionService = {
         amount,
         fee,
         token,
-        chain_id
+        chain_id,
+        user_notes: user_notes || ''
       });
     } catch (error: unknown) {
       // avoid throw error

--- a/src/types/commonType.ts
+++ b/src/types/commonType.ts
@@ -103,6 +103,7 @@ export interface TransactionData {
   status: string;
   chain_id: number;
   date?: Date;
+  user_notes?: string;
 }
 
 export interface ConversionRates {

--- a/test/models/transactionModel.test.ts
+++ b/test/models/transactionModel.test.ts
@@ -34,7 +34,8 @@ describe('Transaction Model', () => {
       amount: 100.5,
       fee: 0.5,
       token: 'ETH',
-      chain_id: 1
+      chain_id: 1,
+      user_notes: 'Test transaction'
     };
 
     const transaction = new Transaction(validTransaction);
@@ -76,7 +77,8 @@ describe('Transaction Model', () => {
       amount: 50.0,
       fee: 0.5,
       token: 'ETH',
-      chain_id: 1
+      chain_id: 1,
+      user_notes: 'Test transaction'
     };
 
     const duplicateTransactionData: Partial<ITransaction> = {
@@ -89,7 +91,8 @@ describe('Transaction Model', () => {
       amount: 75.0,
       fee: 0.5,
       token: 'BTC',
-      chain_id: 1
+      chain_id: 1,
+      user_notes: 'Test transaction'
     };
 
     const transaction1 = new Transaction(transactionData);
@@ -121,7 +124,8 @@ describe('Transaction Model', () => {
       amount: 1000000000.0, // Large amount
       fee: 0.5,
       token: 'USDT',
-      chain_id: 1
+      chain_id: 1,
+      user_notes: 'Test transaction'
     };
 
     const transaction = new Transaction(validTransaction);


### PR DESCRIPTION
### Changes:

- Updated notification template caching to be language-aware, ensuring that cache keys now include both notification type and user language. This prevents incorrect template reuse across different locales and guarantees users always receive messages in their preferred language.
- Added support for **optional user notes on transfers**. Users can now add a short personal message when sending funds. The note is stored in the transaction record, included in notifications (incoming and outgoing), and available through the API. If no note is provided, the flow and templates remain unchanged. This enhancement improves the transfer experience by allowing senders to add context or a personal touch to their transactions.

### Closes:

- #574
- #577

