### PR TITLE
merge feature/20250907 into develop

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -188,3 +188,6 @@ export const CACHE_TOR_CHECK_PERIOD = 3700; // 62 min
 
 export const CACHE_COINGECKO_TTL = 60; // 1 min
 export const CACHE_COINGECKO_CHECK_PERIOD = 120; // 2 min
+
+export const CACHE_ERC20_DATA_TTL = 432000; // 5 days
+export const CACHE_ERC20_DATA_CHECK_PERIOD = 518400; // 6 days

--- a/src/helpers/paymasterHelper.ts
+++ b/src/helpers/paymasterHelper.ts
@@ -41,14 +41,7 @@ export async function createPaymasterAndData(
   // Log debugging information
   Logger.log(
     'Debugging createPaymasterAndData:',
-    `
-    - userProxyAddress: ${userProxyAddress}
-    - expirationTimestamp: ${expirationTimestamp}
-    - chainId: ${actualChainId}
-    - entryPointAddress: ${entryPointAddress}
-    - callData (first 100 chars): ${callData.substring(0, 100)}
-    - encodedData: ${encodedData}
-    - messageHash: ${messageHash}`
+    `userProxyAddress: ${userProxyAddress},expirationTimestamp: ${expirationTimestamp}, chainId: ${actualChainId}, entryPointAddress: ${entryPointAddress}, callData (first 100 chars): ${callData.substring(0, 100)}, encodedData: ${encodedData}, messageHash: ${messageHash}`
   );
 
   // Combine all components

--- a/src/services/cache/cacheService.ts
+++ b/src/services/cache/cacheService.ts
@@ -1,24 +1,26 @@
+// cacheService.ts
 import NodeCache from 'node-cache';
 
 import { CacheNames } from '../../types/commonType';
+import { Logger } from '../../helpers/loggerHelper';
 import {
   CACHE_ABI_TTL,
   CACHE_TOR_TTL,
   CACHE_PRICE_TTL,
   CACHE_OPENSEA_TTL,
   CACHE_COINGECKO_TTL,
+  CACHE_ERC20_DATA_TTL,
   CACHE_ABI_CHECK_PERIOD,
   CACHE_NOTIFICATION_TTL,
   CACHE_TOR_CHECK_PERIOD,
   CACHE_PRICE_CHECK_PERIOD,
   CACHE_OPENSEA_CHECK_PERIOD,
   CACHE_COINGECKO_CHECK_PERIOD,
+  CACHE_ERC20_DATA_CHECK_PERIOD,
   CACHE_NOTIFICATION_CHECK_PERIOD
 } from '../../config/constants';
 
-/**
- * TTL and checkperiod configurations (in seconds).
- */
+/** TTL and checkperiod (seconds) */
 const TTL_CONFIG = {
   [CacheNames.OPENSEA]: { stdTTL: CACHE_OPENSEA_TTL, checkperiod: CACHE_OPENSEA_CHECK_PERIOD },
   [CacheNames.PRICE]: { stdTTL: CACHE_PRICE_TTL, checkperiod: CACHE_PRICE_CHECK_PERIOD },
@@ -28,33 +30,91 @@ const TTL_CONFIG = {
     checkperiod: CACHE_NOTIFICATION_CHECK_PERIOD
   },
   [CacheNames.TOR]: { stdTTL: CACHE_TOR_TTL, checkperiod: CACHE_TOR_CHECK_PERIOD },
-  [CacheNames.COINGECKO]: { stdTTL: CACHE_COINGECKO_TTL, checkperiod: CACHE_COINGECKO_CHECK_PERIOD }
+  [CacheNames.COINGECKO]: {
+    stdTTL: CACHE_COINGECKO_TTL,
+    checkperiod: CACHE_COINGECKO_CHECK_PERIOD
+  },
+  [CacheNames.ERC20]: { stdTTL: CACHE_ERC20_DATA_TTL, checkperiod: CACHE_ERC20_DATA_CHECK_PERIOD }
 };
 
-/**
- * Initialize NodeCache instances per cache category.
- */
 const caches: Record<CacheNames, NodeCache> = {
   [CacheNames.OPENSEA]: new NodeCache(TTL_CONFIG[CacheNames.OPENSEA]),
   [CacheNames.PRICE]: new NodeCache(TTL_CONFIG[CacheNames.PRICE]),
   [CacheNames.ABI]: new NodeCache(TTL_CONFIG[CacheNames.ABI]),
   [CacheNames.NOTIFICATION]: new NodeCache(TTL_CONFIG[CacheNames.NOTIFICATION]),
   [CacheNames.TOR]: new NodeCache(TTL_CONFIG[CacheNames.TOR]),
-  [CacheNames.COINGECKO]: new NodeCache(TTL_CONFIG[CacheNames.COINGECKO])
+  [CacheNames.COINGECKO]: new NodeCache(TTL_CONFIG[CacheNames.COINGECKO]),
+  [CacheNames.ERC20]: new NodeCache(TTL_CONFIG[CacheNames.ERC20])
 };
 
-/**
- * Centralized cache service for getting/setting/clearing data across all cache types.
- */
+// De-duplication of concurrent loads (global, cross-cache)
+const inflightGlobal = new Map<string, Promise<unknown>>();
+
+const inflightKey = (cacheName: CacheNames, key: string) => `${cacheName}:${key}`;
+
+// --- Overloads ---
+function cacheGet<T>(cacheName: CacheNames, key: string): T | undefined;
+
+function cacheGet<T>(
+  cacheName: CacheNames,
+  key: string,
+  loader: () => Promise<T>,
+  ttl?: number
+): Promise<T>;
+
+// --- Single implementation ---
+function cacheGet(
+  cacheName: CacheNames,
+  key: string,
+  loader?: () => Promise<unknown>,
+  ttl?: number
+): unknown {
+  // Mode 1: sync (legacy-compatible)
+  if (!loader) {
+    return caches[cacheName].get(key);
+  }
+
+  // Mode 2: async with loader + dedupe
+  const hit = caches[cacheName].get(key);
+  if (hit !== undefined) {
+    Logger.log('cacheService:get', `CACHE HIT key=${key} [${cacheName}]`);
+    return Promise.resolve(hit);
+  }
+
+  const ikey = inflightKey(cacheName, key);
+  const existing = inflightGlobal.get(ikey);
+  if (existing) {
+    Logger.log('cacheService:get', `INFLIGHT HIT key=${key} [${cacheName}]`);
+    return existing;
+  }
+
+  Logger.log('cacheService:get', `CACHE MISS key=${key} [${cacheName}] — loading...`);
+
+  const p = (async () => {
+    try {
+      const value = await loader();
+      if (ttl !== undefined) {
+        caches[cacheName].set(key, value, ttl);
+      } else {
+        caches[cacheName].set(key, value);
+      }
+      return value;
+    } finally {
+      inflightGlobal.delete(ikey);
+    }
+  })();
+
+  inflightGlobal.set(ikey, p);
+  return p;
+}
+
 export const cacheService = {
-  get: <T>(cacheName: CacheNames, key: string): T | undefined => caches[cacheName]?.get<T>(key),
+  // unified get (sync or async with loader)
+  get: cacheGet,
 
   set: <T>(cacheName: CacheNames, key: string, value: T, ttl?: number): void => {
-    if (ttl !== undefined) {
-      caches[cacheName].set<T>(key, value, ttl);
-    } else {
-      caches[cacheName].set<T>(key, value);
-    }
+    if (ttl !== undefined) caches[cacheName].set<T>(key, value, ttl);
+    else caches[cacheName].set<T>(key, value);
   },
 
   remove: (cacheName: CacheNames, key: string): void => {
@@ -74,5 +134,50 @@ export const cacheService = {
   },
 
   isValidCacheName: (name: string): name is CacheNames =>
-    Object.values(CacheNames).includes(name as CacheNames)
+    Object.values(CacheNames).includes(name as CacheNames),
+
+  /**
+   * Get from cache; if missing, dedupe concurrent loads using a shared Promise.
+   */
+  async getOrLoad<T>(
+    cacheName: CacheNames,
+    key: string,
+    loader: () => Promise<T>,
+    ttl?: number
+  ): Promise<T> {
+    // 1) L2 NodeCache
+    const cached = caches[cacheName].get<T>(key);
+    if (cached !== undefined) {
+      // Log mínimo, como pediste
+      Logger.log('cacheService:getOrLoad', `CACHE HIT key=${key} [${cacheName}]`);
+      return cached;
+    }
+
+    // 2) In-flight dedup
+    const ikey = inflightKey(cacheName, key);
+    const existing = inflightGlobal.get(ikey) as Promise<T> | undefined;
+    if (existing) {
+      Logger.log('cacheService:getOrLoad', `INFLIGHT HIT key=${key} [${cacheName}]`);
+      return existing;
+    }
+
+    Logger.log('cacheService:getOrLoad', `CACHE MISS key=${key} [${cacheName}] — loading...`);
+
+    const p = (async () => {
+      try {
+        const value = await loader();
+        if (ttl !== undefined) {
+          caches[cacheName].set<T>(key, value, ttl);
+        } else {
+          caches[cacheName].set<T>(key, value);
+        }
+        return value;
+      } finally {
+        inflightGlobal.delete(ikey);
+      }
+    })();
+
+    inflightGlobal.set(ikey, p);
+    return p;
+  }
 };

--- a/src/types/commonType.ts
+++ b/src/types/commonType.ts
@@ -143,7 +143,8 @@ export enum CacheNames {
   ABI = 'abiCache',
   NOTIFICATION = 'notificationTemplateCache',
   TOR = 'torCache',
-  COINGECKO = 'coingeckoCache'
+  COINGECKO = 'coingeckoCache',
+  ERC20 = 'erc20'
 }
 
 export const notificationLanguages = ['en', 'es', 'pt'] as const;

--- a/src/types/commonType.ts
+++ b/src/types/commonType.ts
@@ -38,6 +38,7 @@ export interface TokenBalance extends TokenInfo {
 export interface BalanceInfo {
   network: string;
   token: string;
+  tokenAddress?: string;
   balance: number;
   balance_conv: Record<Currency, number>;
 }


### PR DESCRIPTION
### Changes

- CacheService: Implemented an in-flight promise map so concurrent requests for the same cache key shared a single load. This eliminated thundering-herd fetches, reduced latency/cost, and standardized logging to simple HIT/MISS/INFLIGHT events.
- In getBalances: Adopted a `norm(symbol) = trim + toUpperCase` helper across all code paths and centralized a `STABLES` set priced at 1 in both normal and fallback flows. This ensured consistent price resolution and accurate fiat conversions end to end.

### Related to

- #582 
- #583 
