### PR TITLE
merge feature/onramp-wallet-endpoint into develop

### DIFF
--- a/src/api/walletRoutes.ts
+++ b/src/api/walletRoutes.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 
-import { createWallet, withdrawAllFunds } from '../controllers/walletController';
+import { createWallet, getRampWallet, withdrawAllFunds } from '../controllers/walletController';
 
 /**
  * Configures routes related to wallets.
@@ -8,6 +8,13 @@ import { createWallet, withdrawAllFunds } from '../controllers/walletController'
  * @returns {Promise<void>} Resolves once all routes are registered
  */
 export const walletRouter = async (fastify: FastifyInstance): Promise<void> => {
+  /**
+   * Route to get just the wallet to use with ramp-prompts
+   * @route POST /get_ramp_wallet/
+   * @returns {Object} The details of the user wallet
+   */
+  fastify.post('/get_ramp_wallet/', getRampWallet);
+
   /**
    * Route to get or create a wallet
    * @route POST /get_wallet/

--- a/src/controllers/walletController.ts
+++ b/src/controllers/walletController.ts
@@ -1,6 +1,6 @@
 import { once as onceEvent } from 'events';
-import { FastifyReply, FastifyRequest } from 'fastify';
 import { ServerResponse, IncomingMessage } from 'http';
+import { FastifyReply, FastifyRequest } from 'fastify';
 
 import { Logger } from '../helpers/loggerHelper';
 import { delaySeconds } from '../helpers/timeHelper';
@@ -13,6 +13,64 @@ import {
   sendWalletCreationNotification,
   sendWalletAlreadyExistsNotification
 } from '../services/notificationService';
+
+/**
+ * Retrieves the ChatterPay wallet address associated with the given user.
+ * If the wallet does not exist, it will be created automatically.
+ *
+ * This endpoint is typically used by the on-ramp flow to obtain the user's wallet
+ * address before redirecting them to an external provider (e.g., Onramp.Money).
+ *
+ * @param {FastifyRequest<{
+ *   Body: { channel_user_id: string };
+ *   Querystring?: { lastBotMsgDelaySeconds?: number };
+ * }>} request - Fastify request containing the user's WhatsApp ID or phone number.
+ *
+ * @param {FastifyReply} reply - Fastify reply object used to send the HTTP response.
+ *
+ * @returns {Promise<FastifyReply>} A promise that resolves with the user's wallet
+ * address in the HTTP response, or an error if the process fails.
+ */
+export const getRampWallet = async (
+  request: FastifyRequest<{
+    Body: { channel_user_id: string };
+    Querystring?: { lastBotMsgDelaySeconds?: number };
+  }>,
+  reply: FastifyReply
+): Promise<FastifyReply> => {
+  try {
+    if (!request.body) throw new Error('Missing request body');
+
+    const { channel_user_id } = request.body;
+    if (!channel_user_id) throw new Error('Missing channel_user_id in body');
+
+    if (!isValidPhoneNumber(channel_user_id)) {
+      return await returnSuccessResponse(reply, `Invalid phone number: '${channel_user_id}'`);
+    }
+
+    const logKey = `[op:getRampWallet:${channel_user_id}]`;
+    const { networkConfig } = request.server;
+
+    const { message, walletAddress } = await createOrReturnWallet(
+      channel_user_id,
+      networkConfig,
+      logKey
+    );
+
+    Logger.log('getRampWallet', logKey, `${message}, ${walletAddress}`);
+
+    return await returnSuccessResponse(reply, walletAddress);
+  } catch (error) {
+    const err = error as Error;
+    return returnErrorResponse(
+      'getRampWallet',
+      err.message ?? '',
+      reply,
+      500,
+      'Internal Server Error'
+    );
+  }
+};
 
 /**
  * Handles the creation of a new wallet for the user.


### PR DESCRIPTION
### Changes

- Added a new endpoint that returned only the user’s existing wallet address for the ramp process. No wallet creation, no warnings — just the raw wallet address in the response.


### Related To:

- #631