### PR TITLE
merge fix/671-prevent-self-transfer-bypass into develop

### DIFF
--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -112,7 +112,7 @@ const validateInputs = async (
     return 'Too many decimal places (maximum allowed is 18)';
   }
 
-  if (channel_user_id.trim() === to.trim()) {
+  if (isValidPhoneNumber(channel_user_id.trim())  === isValidPhoneNumber(to.trim())) {
     return 'You cannot send money to yourself';
   }
 

--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -112,7 +112,7 @@ const validateInputs = async (
     return 'Too many decimal places (maximum allowed is 18)';
   }
 
-  if (isValidPhoneNumber(channel_user_id.trim())  === isValidPhoneNumber(to.trim())) {
+  if (isValidPhoneNumber(channel_user_id.trim()) === isValidPhoneNumber(to.trim())) {
     return 'You cannot send money to yourself';
   }
 


### PR DESCRIPTION
### Changes

- The self-transfer validation in the send funds flow was updated to compare normalized phone numbers rather than raw string values, preventing users from bypassing the check through formatting differences and ensuring transfers to the sender’s own number were consistently blocked.

### Related To

- #671