### PR TITLE
merge fix/674-multicall-failure into develop

### DIFF
--- a/src/services/web3/multicallService.ts
+++ b/src/services/web3/multicallService.ts
@@ -89,6 +89,16 @@ export async function getTokenBalancesMulticall(
       `Fetching ${tokenAddresses.length} tokens with ${calls.length} calls (vs ${tokenAddresses.length * 2} without multicall)`
     );
 
+    const [network, code] = await Promise.all([
+      provider.getNetwork().catch(() => null),
+      provider.getCode(MULTICALL3_ADDRESS)
+    ]);
+
+    if (!code || code === '0x') {
+      const chainId = network?.chainId ?? 'unknown';
+      throw new Error(`Multicall3 not deployed at ${MULTICALL3_ADDRESS} on chainId ${chainId}`);
+    }
+
     // Execute multicall - use callStatic to force a read operation (not a transaction)
     const startTime = Date.now();
     const results: MulticallResult[] = await multicallContract.callStatic.aggregate3(calls);


### PR DESCRIPTION
### Changes

- Added a preflight check in `getTokenBalancesMulticall` to fetch the network and confirm that Multicall3 bytecode exists at the configured address, throwing a clear error when it is not deployed on the current chain.
- Updated the logger to serialize `Error` instances with their message, code, reason, method, data, and stack so multicall failures no longer appeared as `{}`. 

### Related To

- #674