### PR TITLE
merge feature/666-utility-dual-payload-incoming-transfer into develop

### DIFF
--- a/src/models/templateModel.ts
+++ b/src/models/templateModel.ts
@@ -27,9 +27,16 @@ export interface LocalizedContentType {
   pt: string;
 }
 
+export interface NotificationUtilityConfigType {
+  enabled: boolean;
+  template_key: string;
+  param_order: string[];
+}
+
 export interface NotificationTemplateType {
   title: LocalizedContentType;
   message: LocalizedContentType;
+  utility?: NotificationUtilityConfigType;
 }
 
 export interface NotificationTemplatesTypes {
@@ -52,7 +59,18 @@ const localizedContentSchema = new Schema<LocalizedContentType>({
 
 const notificationSchema = new Schema<NotificationTemplateType>({
   title: { type: localizedContentSchema, required: true },
-  message: { type: localizedContentSchema, required: true }
+  message: { type: localizedContentSchema, required: true },
+  utility: {
+    type: new Schema<NotificationUtilityConfigType>(
+      {
+        enabled: { type: Boolean, required: true },
+        template_key: { type: String, required: true },
+        param_order: { type: [String], required: true }
+      },
+      { _id: false }
+    ),
+    required: false
+  }
 });
 
 const templateSchema = new Schema<ITemplateSchema>({

--- a/src/types/chatizaloType.ts
+++ b/src/types/chatizaloType.ts
@@ -2,4 +2,8 @@ export interface chatizaloOperatorReply {
   data_token: string;
   channel_user_id: string;
   message: string;
+  message_kind?: 'marketing' | 'utility' | 'auth';
+  preferred_language?: 'es' | 'pt' | 'en';
+  template_key?: string;
+  template_params?: readonly string[];
 }

--- a/test/globalSetup.ts
+++ b/test/globalSetup.ts
@@ -1,0 +1,36 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function createMongoServerWithRetry(retries = 3): Promise<MongoMemoryServer> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await MongoMemoryServer.create({
+        binary: {
+          version: '7.0.14'
+        },
+        instance: {
+          storageEngine: 'wiredTiger'
+        }
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await wait(500 * attempt);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+export default async function globalSetup() {
+  const mongoServer = await createMongoServerWithRetry(3);
+  process.env.MONGO_MEMORY_SERVER_URI = mongoServer.getUri();
+
+  return async () => {
+    await mongoServer.stop();
+  };
+}

--- a/test/models/blockchainModel.test.ts
+++ b/test/models/blockchainModel.test.ts
@@ -1,24 +1,9 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import Blockchain, { type IBlockchain } from '../../src/models/blockchainModel';
 
 describe('Blockchain Model', () => {
-  let mongoServer: MongoMemoryServer;
-
-  beforeEach(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
-    await mongoose.disconnect();
-    await mongoose.connect(uri, {});
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
-  });
-
   it('should fail to save without required fields', async () => {
     const invalidBlockchain: Partial<IBlockchain> = {
       chainId: 1,

--- a/test/models/chatterpointsModel.test.ts
+++ b/test/models/chatterpointsModel.test.ts
@@ -1,6 +1,4 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
-import mongoose from 'mongoose';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   ChatterpointsModel,
@@ -10,20 +8,8 @@ import {
 } from '../../src/models/chatterpointsModel';
 
 describe('Chatterpoints Model', () => {
-  let mongoServer: MongoMemoryServer;
-
   beforeEach(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
-
-    await mongoose.disconnect();
-    await mongoose.connect(uri, {});
     await ChatterpointsModel.syncIndexes();
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
   });
 
   const now = () => new Date();

--- a/test/models/nftModel.test.ts
+++ b/test/models/nftModel.test.ts
@@ -1,25 +1,9 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import NFTModel, { type INFT } from '../../src/models/nftModel';
 
 describe('NFT Model', () => {
-  let mongoServer: MongoMemoryServer;
-
-  beforeEach(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
-
-    await mongoose.disconnect();
-    await mongoose.connect(uri, {});
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
-  });
-
   it('should create and save an NFT document successfully', async () => {
     const validNFT: Partial<INFT> = {
       channel_user_id: 'user123',

--- a/test/models/templateModel.test.ts
+++ b/test/models/templateModel.test.ts
@@ -1,6 +1,5 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   type ITemplateSchema,
@@ -10,21 +9,6 @@ import {
 } from '../../src/models/templateModel';
 
 describe('Template Model', () => {
-  let mongoServer: MongoMemoryServer;
-
-  beforeEach(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
-
-    await mongoose.disconnect();
-    await mongoose.connect(uri, {});
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
-  });
-
   it('should create and save a Template document successfully', async () => {
     type TestTemplateSchema = Partial<ITemplateSchema>;
 

--- a/test/models/tokenModel.test.ts
+++ b/test/models/tokenModel.test.ts
@@ -1,24 +1,11 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import Token, { type IToken } from '../../src/models/tokenModel';
 
 describe('Token Model', () => {
-  let mongoServer: MongoMemoryServer;
-
   beforeEach(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
-
-    await mongoose.disconnect();
-    await mongoose.connect(uri, {});
     await Token.syncIndexes(); // Ensures unique indexes in the in-memory database
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
   });
 
   it('should create and save a Token document successfully with operations limits', async () => {

--- a/test/models/transactionModel.test.ts
+++ b/test/models/transactionModel.test.ts
@@ -1,26 +1,11 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import Transaction, { type ITransaction } from '../../src/models/transactionModel';
 
 describe('Transaction Model', () => {
-  let mongoServer: MongoMemoryServer;
-
   beforeEach(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
-
-    await mongoose.disconnect();
-    await mongoose.connect(uri, {});
     await Transaction.syncIndexes(); // Ensures unique indexes
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
-    if (mongoServer) {
-      await mongoServer.stop();
-    }
   });
 
   it('should create and save a Transaction document successfully', async () => {

--- a/test/models/userModel.test.ts
+++ b/test/models/userModel.test.ts
@@ -1,25 +1,9 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { SETTINGS_NOTIFICATION_LANGUAGE_DEFAULT } from '../../src/config/constants';
 import { type IUser, type IUserWallet, UserModel } from '../../src/models/userModel';
 
 describe('User Model', () => {
-  let mongoServer: MongoMemoryServer;
-
-  beforeEach(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
-
-    await mongoose.disconnect();
-    await mongoose.connect(uri, {});
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
-  });
-
   it('should create and save a User document successfully', async () => {
     const validUser: Partial<IUser> = {
       name: 'John Doe',

--- a/test/services/mongo/mongoReferralService.test.ts
+++ b/test/services/mongo/mongoReferralService.test.ts
@@ -1,26 +1,9 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
-import mongoose from 'mongoose';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { UserModel } from '../../../src/models/userModel';
 import { mongoReferralService } from '../../../src/services/mongo/mongoReferralService';
 
 describe('mongoReferralService.getReferralByCodeByPhoneNumber', () => {
-  let mongoServer: MongoMemoryServer;
-
-  beforeEach(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
-
-    await mongoose.disconnect();
-    await mongoose.connect(uri, {});
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
-  });
-
   it('returns empty string when user exists but referral_by_code field is missing', async () => {
     // Insert raw doc to simulate legacy data where field was never set.
     await UserModel.collection.insertOne({

--- a/test/services/notificationService.transferUtility.test.ts
+++ b/test/services/notificationService.transferUtility.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NotificationEnum, TemplateType } from '../../src/models/templateModel';
+import { UserModel } from '../../src/models/userModel';
+import { cacheService } from '../../src/services/cache/cacheService';
+import { chatizaloService } from '../../src/services/chatizalo/chatizaloService';
+import {
+  persistAndSendNotification,
+  sendReceivedTransferNotification
+} from '../../src/services/notificationService';
+
+vi.mock('../../src/services/chatizalo/chatizaloService', () => ({
+  chatizaloService: {
+    sendBotNotification: vi.fn().mockResolvedValue('ok')
+  }
+}));
+
+describe('notificationService (transfer utility dual payload)', () => {
+  const seedTemplates = async (opts: { incomingUtilityEnabled: boolean }) => {
+    const baseNotification = {
+      title: { en: 'Title', es: 'Title', pt: 'Title' },
+      message: { en: 'Message', es: 'Message', pt: 'Message' }
+    };
+
+    const notifications: Record<string, unknown> = Object.fromEntries(
+      Object.values(NotificationEnum).map((key) => [key, baseNotification])
+    );
+
+    notifications[NotificationEnum.incoming_transfer] = {
+      title: { en: 'Incoming', es: 'Incoming', pt: 'Incoming' },
+      message: {
+        en: 'From [FROM] sent [AMOUNT] [TOKEN][USER_NOTES]',
+        es: 'From [FROM] sent [AMOUNT] [TOKEN][USER_NOTES]',
+        pt: 'From [FROM] sent [AMOUNT] [TOKEN][USER_NOTES]'
+      },
+      ...(opts.incomingUtilityEnabled
+        ? {
+            utility: {
+              enabled: true,
+              template_key: 'transfer_update',
+              param_order: ['from', 'amount', 'token']
+            }
+          }
+        : {})
+    };
+
+    await TemplateType.create({ notifications });
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    cacheService.clearAllCaches();
+  });
+
+  it('Case A: incoming_transfer with utility config sends dual payload', async () => {
+    await UserModel.create({
+      phone_number: '2222222222',
+      wallets: [],
+      settings: { notifications: { language: 'es' } }
+    });
+    await seedTemplates({ incomingUtilityEnabled: true });
+
+    await sendReceivedTransferNotification(
+      '1111111111',
+      'Alice',
+      '2222222222',
+      '10.50',
+      'USDC',
+      'Thanks'
+    );
+
+    expect(chatizaloService.sendBotNotification).toHaveBeenCalledTimes(1);
+
+    const payload = (chatizaloService.sendBotNotification as any).mock.calls[0][0];
+    expect(payload.channel_user_id).toBe('2222222222');
+    expect(payload.message).toBe("From 1111111111 (Alice) sent 10.50 USDC\n('Thanks')");
+
+    expect(payload.message_kind).toBe('utility');
+    expect(payload.preferred_language).toBe('es');
+    expect(payload.template_key).toBe('transfer_update');
+    expect(payload.template_params).toEqual(['1111111111 (Alice)', '10.50', 'USDC']);
+  });
+
+  it('Case B: incoming_transfer without utility config keeps legacy payload', async () => {
+    await UserModel.create({
+      phone_number: '2222222222',
+      wallets: [],
+      settings: { notifications: { language: 'en' } }
+    });
+    await seedTemplates({ incomingUtilityEnabled: false });
+
+    await sendReceivedTransferNotification(
+      '1111111111',
+      'Alice',
+      '2222222222',
+      '10.50',
+      'USDC',
+      ''
+    );
+
+    expect(chatizaloService.sendBotNotification).toHaveBeenCalledTimes(1);
+
+    const payload = (chatizaloService.sendBotNotification as any).mock.calls[0][0];
+    expect(payload.channel_user_id).toBe('2222222222');
+    expect(payload).not.toHaveProperty('message_kind');
+    expect(payload).not.toHaveProperty('preferred_language');
+    expect(payload).not.toHaveProperty('template_key');
+    expect(payload).not.toHaveProperty('template_params');
+  });
+
+  it('Case C: outgoing_transfer payload remains text-only', async () => {
+    await persistAndSendNotification({
+      to: '2222222222',
+      messageBot: 'Outgoing transfer message',
+      messagePush: 'Outgoing transfer message',
+      template: NotificationEnum.outgoing_transfer,
+      sendBot: true
+    });
+
+    expect(chatizaloService.sendBotNotification).toHaveBeenCalledTimes(1);
+
+    const payload = (chatizaloService.sendBotNotification as any).mock.calls[0][0];
+    expect(payload.channel_user_id).toBe('2222222222');
+    expect(payload.message).toBe('Outgoing transfer message');
+    expect(payload).not.toHaveProperty('message_kind');
+    expect(payload).not.toHaveProperty('preferred_language');
+    expect(payload).not.toHaveProperty('template_key');
+    expect(payload).not.toHaveProperty('template_params');
+  });
+});

--- a/test/services/securityService.test.ts
+++ b/test/services/securityService.test.ts
@@ -1,6 +1,4 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
-import mongoose from 'mongoose';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { SECURITY_PIN_MAX_FAILED_ATTEMPTS } from '../../src/config/constants';
 import { TemplateType } from '../../src/models/templateModel';
@@ -8,15 +6,7 @@ import { UserModel } from '../../src/models/userModel';
 import { securityService } from '../../src/services/securityService';
 
 describe('securityService', () => {
-  let mongoServer: MongoMemoryServer;
-
   beforeEach(async () => {
-    mongoServer = await MongoMemoryServer.create();
-    const uri = mongoServer.getUri();
-
-    await mongoose.disconnect();
-    await mongoose.connect(uri, {});
-
     // Create a test user
     await UserModel.create({
       phone_number: '1234567890',
@@ -76,11 +66,6 @@ describe('securityService', () => {
         }
       }
     });
-  });
-
-  afterEach(async () => {
-    await mongoose.disconnect();
-    await mongoServer.stop();
   });
 
   describe('setPin', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    globalSetup: ['./test/globalSetup.ts'],
     globals: true,
     environment: 'node',
+    pool: 'forks',
+    fileParallelism: false,
+    maxWorkers: 1,
     dir: 'test',
     exclude: ['**/node_modules/**', '**/dist/**'],
     coverage: {


### PR DESCRIPTION
### Changes

* Enhanced **incoming transfer** notifications to optionally support a **dual payload**: the existing rendered free-text message (for delivery inside WhatsApp’s customer service window) plus **Utility template** metadata (for delivery outside the window), improving reliability without changing the current UX.
* Kept the change **strictly scoped** to transfer notifications: **outgoing_transfer** remained **text-only** and unchanged, while **incoming_transfer** included Utility fields **only when** a Utility configuration was present and enabled in the templates configuration.
* Extended the bot request to `POST /chatbot/conversations/send-message` in a **backward-compatible** way by adding **optional** fields (`message_kind`, `preferred_language`, `template_key`, `template_params`) while ensuring that, when Utility config was absent, the payload remained **bit-for-bit equivalent** to the legacy behavior.
* Added **multi-language support** for the new fields with `es`, `pt`, `en` and an automatic **fallback to `en`**, using locale normalization rules (prefix-based selection for `es`/`pt`, otherwise `en`).
* Implemented deterministic **positional parameter mapping** for the approved Meta Utility template using `utility.param_order` and generating `template_params = [from_phone, from_name, amount, token]`, explicitly excluding free-form user notes from template parameters and keeping such notes only in the free-text message.
* Added minimal verification coverage for the three critical cases: Utility-enabled incoming transfer includes correct optional fields and ordered parameters; Utility-disabled incoming transfer remains legacy-identical; outgoing transfer remains unchanged.

### Related To

- #666