### PR TITLE
merge feature/meta-new-templates into develop

### DIFF
--- a/src/models/templateModel.ts
+++ b/src/models/templateModel.ts
@@ -2,6 +2,7 @@ import { type Document, model, Schema } from 'mongoose';
 
 export enum NotificationEnum {
   incoming_transfer = 'incoming_transfer',
+  incoming_transfer_w_note = 'incoming_transfer_w_note',
   incoming_transfer_external = 'incoming_transfer_external',
   swap = 'swap',
   mint = 'mint',
@@ -76,6 +77,7 @@ const notificationSchema = new Schema<NotificationTemplateType>({
 const templateSchema = new Schema<ITemplateSchema>({
   notifications: {
     incoming_transfer: { type: notificationSchema, required: true },
+    incoming_transfer_w_note: { type: notificationSchema, required: true },
     incoming_transfer_external: { type: notificationSchema, required: true },
     swap: { type: notificationSchema, required: true },
     mint: { type: notificationSchema, required: true },

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -364,6 +364,7 @@ export async function sendReceivedExternalTransferNotification(
       amount,
       token
     };
+    const utilityParamOrder = utilityConfig?.param_order ?? [];
 
     const sendAndPersistParams: SendAndPersistParams = {
       to: phoneNumberTo,
@@ -381,9 +382,7 @@ export async function sendReceivedExternalTransferNotification(
               await mongoUserService.getUserSettingsLanguage(phoneNumberTo)
             ),
             template_key: utilityConfig.template_key,
-            template_params: (utilityParamOrder ?? []).map(
-              (param) => templateParamsValues[param] ?? ''
-            )
+            template_params: utilityParamOrder.map((param) => templateParamsValues[param] ?? '')
           }
         : {})
     };

--- a/test/models/templateModel.test.ts
+++ b/test/models/templateModel.test.ts
@@ -26,6 +26,18 @@ describe('Template Model', () => {
             pt: 'Sua transferência foi bem-sucedida.'
           }
         },
+        incoming_transfer_w_note: {
+          title: {
+            en: 'Transfer completed',
+            es: 'Transferencia completada',
+            pt: 'Transferência concluída'
+          },
+          message: {
+            en: 'Your transfer was successful.',
+            es: 'Tu transferencia fue exitosa.',
+            pt: 'Sua transferência foi bem-sucedida.'
+          }
+        },
         incoming_transfer_external: {
           title: {
             en: 'External Transfer completed',

--- a/test/services/notificationService.externalDeposits.test.ts
+++ b/test/services/notificationService.externalDeposits.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NotificationEnum, TemplateType } from '../../src/models/templateModel';
+import { UserModel } from '../../src/models/userModel';
+import { cacheService } from '../../src/services/cache/cacheService';
+import { chatizaloService } from '../../src/services/chatizalo/chatizaloService';
+import { sendReceivedExternalTransferNotification } from '../../src/services/notificationService';
+
+vi.mock('../../src/services/chatizalo/chatizaloService', () => ({
+  chatizaloService: {
+    sendBotNotification: vi.fn().mockResolvedValue('ok')
+  }
+}));
+
+describe('notificationService (external deposit notification)', () => {
+  const seedTemplates = async (opts: { externalUtilityEnabled: boolean }) => {
+    const baseNotification = {
+      title: { en: 'Title', es: 'Title', pt: 'Title' },
+      message: { en: 'Message', es: 'Message', pt: 'Message' }
+    };
+
+    const notifications: Record<string, unknown> = Object.fromEntries(
+      Object.values(NotificationEnum).map((key) => [key, baseNotification])
+    );
+
+    notifications[NotificationEnum.incoming_transfer_external] = {
+      title: { en: 'Incoming', es: 'Incoming', pt: 'Incoming' },
+      message: {
+        en: 'From [FROM] sent [AMOUNT] [TOKEN]',
+        es: 'From [FROM] sent [AMOUNT] [TOKEN]',
+        pt: 'From [FROM] sent [AMOUNT] [TOKEN]'
+      },
+      ...(opts.externalUtilityEnabled
+        ? {
+            utility: {
+              enabled: true,
+              template_key: 'external_deposit_update',
+              param_order: ['from', 'amount', 'token']
+            }
+          }
+        : {})
+    };
+
+    await TemplateType.create({ notifications });
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    cacheService.clearAllCaches();
+  });
+
+  it('Case A: incoming_transfer_external with utility config sends dual payload', async () => {
+    await UserModel.create({
+      phone_number: '2222222222',
+      wallets: [],
+      settings: { notifications: { language: 'es' } }
+    });
+    await seedTemplates({ externalUtilityEnabled: true });
+
+    await sendReceivedExternalTransferNotification(
+      '1111111111',
+      'Alice',
+      '2222222222',
+      '10.50',
+      'USDC'
+    );
+
+    expect(chatizaloService.sendBotNotification).toHaveBeenCalledTimes(1);
+
+    const payload = (chatizaloService.sendBotNotification as any).mock.calls[0][0];
+    expect(payload.channel_user_id).toBe('2222222222');
+    expect(payload.message).toBe('From 1111111111 (Alice) sent 10.50 USDC');
+
+    expect(payload.message_kind).toBe('utility');
+    expect(payload.preferred_language).toBe('es');
+    expect(payload.template_key).toBe('external_deposit_update');
+    expect(payload.template_params).toEqual(['1111111111 (Alice)', '10.50', 'USDC']);
+  });
+
+  it('Case B: incoming_transfer_external without utility config keeps legacy payload', async () => {
+    await UserModel.create({
+      phone_number: '2222222222',
+      wallets: [],
+      settings: { notifications: { language: 'en' } }
+    });
+    await seedTemplates({ externalUtilityEnabled: false });
+
+    await sendReceivedExternalTransferNotification(
+      '3333333333',
+      null,
+      '2222222222',
+      '10.50',
+      'USDC'
+    );
+
+    expect(chatizaloService.sendBotNotification).toHaveBeenCalledTimes(1);
+
+    const payload = (chatizaloService.sendBotNotification as any).mock.calls[0][0];
+    expect(payload.channel_user_id).toBe('2222222222');
+    expect(payload.message).toBe('From 3333333333 sent 10.50 USDC');
+    expect(payload).not.toHaveProperty('message_kind');
+    expect(payload).not.toHaveProperty('preferred_language');
+    expect(payload).not.toHaveProperty('template_key');
+    expect(payload).not.toHaveProperty('template_params');
+  });
+
+  it('Case C: invalid recipient phone skips notification', async () => {
+    await sendReceivedExternalTransferNotification('1111111111', null, 'invalid', '10.50', 'USDC');
+
+    expect(chatizaloService.sendBotNotification).not.toHaveBeenCalled();
+  });
+});

--- a/test/services/notificationService.transferUtility.test.ts
+++ b/test/services/notificationService.transferUtility.test.ts
@@ -26,7 +26,7 @@ describe('notificationService (transfer utility dual payload)', () => {
       Object.values(NotificationEnum).map((key) => [key, baseNotification])
     );
 
-    notifications[NotificationEnum.incoming_transfer] = {
+    const incomingTransferNotification = {
       title: { en: 'Incoming', es: 'Incoming', pt: 'Incoming' },
       message: {
         en: 'From [FROM] sent [AMOUNT] [TOKEN][NOTES]',
@@ -43,6 +43,9 @@ describe('notificationService (transfer utility dual payload)', () => {
           }
         : {})
     };
+
+    notifications[NotificationEnum.incoming_transfer] = incomingTransferNotification;
+    notifications[NotificationEnum.incoming_transfer_w_note] = incomingTransferNotification;
 
     await TemplateType.create({ notifications });
   };

--- a/test/services/notificationService.transferUtility.test.ts
+++ b/test/services/notificationService.transferUtility.test.ts
@@ -29,9 +29,9 @@ describe('notificationService (transfer utility dual payload)', () => {
     notifications[NotificationEnum.incoming_transfer] = {
       title: { en: 'Incoming', es: 'Incoming', pt: 'Incoming' },
       message: {
-        en: 'From [FROM] sent [AMOUNT] [TOKEN][USER_NOTES]',
-        es: 'From [FROM] sent [AMOUNT] [TOKEN][USER_NOTES]',
-        pt: 'From [FROM] sent [AMOUNT] [TOKEN][USER_NOTES]'
+        en: 'From [FROM] sent [AMOUNT] [TOKEN][NOTES]',
+        es: 'From [FROM] sent [AMOUNT] [TOKEN][NOTES]',
+        pt: 'From [FROM] sent [AMOUNT] [TOKEN][NOTES]'
       },
       ...(opts.incomingUtilityEnabled
         ? {

--- a/test/services/securityService.test.ts
+++ b/test/services/securityService.test.ts
@@ -25,6 +25,7 @@ describe('securityService', () => {
     await TemplateType.create({
       notifications: {
         incoming_transfer: mockNotification,
+        incoming_transfer_w_note: mockNotification,
         incoming_transfer_external: mockNotification,
         swap: mockNotification,
         mint: mockNotification,


### PR DESCRIPTION
### Changes

- Support was added to deliver incoming transfer notifications with user-provided notes via a dedicated approved Meta Utility template, ensuring delivery outside WhatsApp’s customer service window while remaining backward compatible. A new notes-enabled template variant was created and approved in English/Spanish/Portuguese with English fallback, and its mapping was registered in the chatbot template registry and in ChatterPay’s notification templates configuration. ChatterPay’s NotificationService was updated to select the notes-enabled template only when the transfer includes notes, while preserving the existing rendered message and all current behavior when notes are absent. The bot endpoint contract remained unchanged, the new behavior only applied when the new Utility configuration was present and enabled, and the change did not affect outgoing transfers.
- Support was added to deliver external deposit notifications using approved Meta Utility templates to ensure delivery outside WhatsApp’s customer service window. The existing rendered text message was preserved unchanged, while an optional template payload (message_kind="utility", template_key from DB/config, preferred_language in es/pt/en with English fallback, and correctly ordered positional parameters) was appended only when the external-deposit Utility configuration was present and enabled. Template translations were created and approved in EN/ES/PT, mappings were registered in the chatbot DB, ChatterPay’s templates configuration was extended accordingly, and the change was scoped strictly to external deposit notifications without impacting other notification types or breaking the bot endpoint contract.


### Related To
- #677 
- #678
