### PR TITLE
merge feature/681-block-short-url-mint-nft into develop

### DIFF
--- a/src/controllers/ImageController.ts
+++ b/src/controllers/ImageController.ts
@@ -6,7 +6,7 @@ import {
   returnErrorResponse500,
   returnSuccessResponse
 } from '../helpers/requestHelper';
-import { isShortUrl } from '../helpers/validationHelper';
+import { isShortUrl, isShortUrlByRedirect } from '../helpers/validationHelper';
 import { downloadAndProcessImage } from '../services/imageService';
 import { ipfsService } from '../services/ipfs/ipfsService';
 import { getUser } from '../services/userService';
@@ -81,7 +81,7 @@ export const uploadImage: RouteHandlerMethod = async (
       return await returnErrorResponse('uploadImage', '', reply, 400, 'Image URL not provided');
     }
 
-    if (isShortUrl(image_url)) {
+    if (isShortUrl(image_url) || (await isShortUrlByRedirect(image_url))) {
       return await returnErrorResponse('uploadImage', '', reply, 400, 'Short Url not allowed');
     }
 

--- a/src/controllers/nftController.ts
+++ b/src/controllers/nftController.ts
@@ -1,4 +1,5 @@
 import { ethers } from 'ethers';
+
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import mongoose, { type ObjectId } from 'mongoose';
 import {
@@ -16,7 +17,12 @@ import {
   returnSuccessResponse
 } from '../helpers/requestHelper';
 import { delaySeconds } from '../helpers/timeHelper';
-import { isShortUrl, isValidPhoneNumber, isValidUrl } from '../helpers/validationHelper';
+import {
+  isShortUrl,
+  isShortUrlByRedirect,
+  isValidPhoneNumber,
+  isValidUrl
+} from '../helpers/validationHelper';
 import NFTModel, { type INFT, type INFTMetadata } from '../models/nftModel';
 import { NotificationEnum } from '../models/templateModel';
 import type { IUser, IUserWallet } from '../models/userModel';
@@ -263,8 +269,8 @@ export const generateNftOriginal = async (
     );
   }
 
-  if (isShortUrl(url)) {
-    return returnErrorResponse('generateNftOriginal', logKey, reply, 400, 'Short Url not allowed');
+  if (isShortUrl(url) || (await isShortUrlByRedirect(url))) {
+    return returnSuccessResponse(reply, 'Short Url not allowed');
   }
 
   const fromUser: IUser | null = await getUser(channel_user_id);

--- a/src/helpers/validationHelper.ts
+++ b/src/helpers/validationHelper.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { type AxiosResponse } from 'axios';
 import { ethers } from 'ethers';
 
 import { short_urls_domains } from '../config/shortUrlsDomains.json';
@@ -79,11 +79,12 @@ const getRedirectInfo = (response: unknown): { finalUrl: string; redirectCount: 
   };
 };
 
-const isNonImageContentType = (contentType?: string): boolean => {
-  if (!contentType) {
+const isNonImageContentType = (contentType?: string | string[]): boolean => {
+  const value = Array.isArray(contentType) ? contentType[0] : contentType;
+  if (!value) {
     return false;
   }
-  return !contentType.toLowerCase().startsWith('image/');
+  return !value.toLowerCase().startsWith('image/');
 };
 
 /**
@@ -105,11 +106,7 @@ export const isShortUrlByRedirect = async (url: string): Promise<boolean> => {
     return false;
   }
 
-  const checkResponse = async (response: {
-    status: number;
-    headers?: Record<string, string | string[]>;
-    data?: { destroy?: () => void };
-  }): Promise<boolean> => {
+  const checkResponse = async (response: AxiosResponse): Promise<boolean> => {
     const { finalUrl, redirectCount } = getRedirectInfo(response);
     if (finalUrl) {
       try {
@@ -122,9 +119,8 @@ export const isShortUrlByRedirect = async (url: string): Promise<boolean> => {
       }
     }
 
-    const contentTypeHeader = response.headers?.['content-type'];
-    const contentType = Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader;
-    if (isNonImageContentType(contentType)) {
+    const contentTypeHeader = response.headers?.['content-type'] as string | string[] | undefined;
+    if (isNonImageContentType(contentTypeHeader)) {
       return true;
     }
 

--- a/test/helpers/validationHelper.test.ts
+++ b/test/helpers/validationHelper.test.ts
@@ -42,6 +42,8 @@ describe('Validation Functions', () => {
     it('should return true for short URLs', () => {
       const shortUrl = `https://${short_urls_domains[0]}/short-url`;
       expect(isShortUrl(shortUrl)).toBe(true);
+      expect(isShortUrl(`www.${short_urls_domains[0]}/short-url`)).toBe(true);
+      expect(isShortUrl(`${short_urls_domains[0]}/short-url`)).toBe(true);
     });
 
     it('should return false for non-short URLs', () => {


### PR DESCRIPTION
### Changes

- Added redirect-based short URL detection with safer host parsing, blocked short URL redirects in image uploads and NFT minting, and expanded validation tests to cover short URL variants.

### Related To

- #681
