### PR TITLE
merge feature/685-avoid-error-no-cycle-open into develop

### DIFF
--- a/src/controllers/chatterpointsController.ts
+++ b/src/controllers/chatterpointsController.ts
@@ -252,7 +252,7 @@ export const stats = async (
     }
     const result = await chatterpointsService.getStats({ cycleId, userId: channel_user_id });
     Logger.debug('stats', 'fetched', { cycleId, userId: channel_user_id });
-    await reply.status(200).send({ status: 'ok', ...result });
+    await reply.status(200).send(result);
   } catch (err) {
     Logger.error('stats', (err as Error).message);
     await reply.status(200).send({ status: 'error', error: (err as Error).message });
@@ -299,7 +299,7 @@ export const social = async (
       granted: result.granted
     });
 
-    await reply.status(200).send({ status: 'ok', ...result });
+    await reply.status(200).send(result);
   } catch (err) {
     Logger.error('social', (err as Error).message);
     await reply.status(200).send({ status: 'error', error: (err as Error).message });


### PR DESCRIPTION
### Changes

- When no OPEN cycle existed, `gamesInfo` raised an exception and logged `No OPEN cycle found`, which interrupted the normal response path and produced an inconsistent outcome for callers expecting a valid payload. The issue was resolved by updating `getCycleGamesInfo` to preserve the same response schema and return default/null values while emitting a debug log instead of throwing, ensuring the API behavior remained stable and predictable even when no cycle was open.


### Related To

- #685