### PR TITLE
merge feature/694-i18n-template-based-sec-pin into develop

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -31,6 +31,7 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+
       "correctness": {
         "noUnusedVariables": "off",
         "noUnusedFunctionParameters": "off"
@@ -48,6 +49,7 @@
         "noBannedTypes": "off"
       },
       "style": {
+        "useImportType": "off",
         "noNonNullAssertion": "off",
         "useNodejsImportProtocol": "off"
       }

--- a/src/models/templateModel.ts
+++ b/src/models/templateModel.ts
@@ -1,4 +1,4 @@
-import { type Document, model, Schema } from 'mongoose';
+import { Document, model, Schema } from 'mongoose';
 
 export enum NotificationEnum {
   incoming_transfer = 'incoming_transfer',
@@ -20,7 +20,12 @@ export enum NotificationEnum {
   aave_supply_info_no_data = 'aave_supply_info_no_data',
   aave_supply_modified = 'aave_supply_modified',
   chatterpoints_operation = 'chatterpoints_operation',
-  cross_chain_disabled = 'cross_chain_disabled'
+  cross_chain_disabled = 'cross_chain_disabled',
+  pin_not_set = 'pin_not_set',
+  pin_invalid_remaining_attempts = 'pin_invalid_remaining_attempts',
+  pin_blocked = 'pin_blocked',
+  pin_verified_success = 'pin_verified_success',
+  pin_internal_error = 'pin_internal_error'
 }
 
 export interface LocalizedContentType {
@@ -41,10 +46,9 @@ export interface NotificationTemplateType {
   utility?: NotificationUtilityConfigType;
 }
 
-export interface NotificationTemplatesTypes {
-  // @ts-expect-error 'mark as error'
+export type NotificationTemplatesTypes = {
   [key in NotificationEnum]: NotificationTemplateType;
-}
+};
 
 export interface ITemplateSchema extends Document {
   notifications: {
@@ -96,7 +100,12 @@ const templateSchema = new Schema<ITemplateSchema>({
     aave_supply_info: { type: notificationSchema, required: true },
     aave_supply_info_no_data: { type: notificationSchema, required: true },
     chatterpoints_operation: { type: notificationSchema, required: true },
-    cross_chain_disabled: { type: notificationSchema, required: true }
+    cross_chain_disabled: { type: notificationSchema, required: true },
+    pin_not_set: { type: notificationSchema, required: true },
+    pin_invalid_remaining_attempts: { type: notificationSchema, required: true },
+    pin_blocked: { type: notificationSchema, required: true },
+    pin_verified_success: { type: notificationSchema, required: true },
+    pin_internal_error: { type: notificationSchema, required: true }
   },
   security_questions: { type: Map, of: localizedContentSchema, required: false }
 });

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -32,15 +32,13 @@ function normalizePreferredLanguage(language: string | null | undefined): 'es' |
 async function getNotificationUtilityConfig(
   typeOfNotification: NotificationEnum
 ): Promise<NotificationUtilityConfigType | undefined> {
-  const templateDocument = await mongoTemplateService.getTemplate<ITemplateSchema>(
+  const notificationTemplates = await mongoTemplateService.getTemplate<NotificationTemplatesTypes>(
     templateEnum.NOTIFICATIONS
   );
 
-  if (!templateDocument) {
-    return undefined;
-  }
+  if (!notificationTemplates) return undefined;
 
-  const template = templateDocument.notifications[typeOfNotification];
+  const template = notificationTemplates[typeOfNotification];
   return template?.utility;
 }
 

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -6,7 +6,6 @@ import { isValidPhoneNumber } from '../helpers/validationHelper';
 
 import type { IBlockchain } from '../models/blockchainModel';
 import {
-  type ITemplateSchema,
   NotificationEnum,
   type NotificationTemplatesTypes,
   type NotificationUtilityConfigType
@@ -70,14 +69,16 @@ export async function getNotificationTemplate(
       return cachedTemplate as { title: string; message: string };
     }
 
-    const notificationTemplates: NotificationTemplatesTypes | null =
-      await mongoTemplateService.getTemplate<ITemplateSchema>(templateEnum.NOTIFICATIONS);
+    const notificationTemplates =
+      await mongoTemplateService.getTemplate<NotificationTemplatesTypes>(
+        templateEnum.NOTIFICATIONS
+      );
+
     if (!notificationTemplates) {
       Logger.warn('getNotificationTemplate', 'Notifications Templates not found');
       return defaultNotification;
     }
 
-    // @ts-expect-error 'expected type error'
     const template = notificationTemplates[typeOfNotification];
 
     if (!template) {

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -32,13 +32,15 @@ function normalizePreferredLanguage(language: string | null | undefined): 'es' |
 async function getNotificationUtilityConfig(
   typeOfNotification: NotificationEnum
 ): Promise<NotificationUtilityConfigType | undefined> {
-  const notificationTemplates: NotificationTemplatesTypes | null =
-    await mongoTemplateService.getTemplate<ITemplateSchema>(templateEnum.NOTIFICATIONS);
-  if (!notificationTemplates) return undefined;
+  const templateDocument = await mongoTemplateService.getTemplate<ITemplateSchema>(
+    templateEnum.NOTIFICATIONS
+  );
 
-  // @ts-expect-error 'expected type error'
-  const template = notificationTemplates[typeOfNotification];
+  if (!templateDocument) {
+    return undefined;
+  }
 
+  const template = templateDocument.notifications[typeOfNotification];
   return template?.utility;
 }
 

--- a/src/services/securityService.ts
+++ b/src/services/securityService.ts
@@ -273,8 +273,7 @@ export const securityService = {
    * @param pin - PIN provided by the user (plain text).
    * @param channel - Source channel for auditing ("bot" | "frontend" | "unknown").
    * @returns VerifyPinResult Verification outcome including status, message, and optional lock/attempt info.
-   */
-  verifyPin: async (
+   */ verifyPin: async (
     phoneNumber: string,
     pin: string,
     channel?: string
@@ -300,13 +299,16 @@ export const securityService = {
         securityState.pin.status === 'blocked'
       ) {
         const blockedUntilIso = new Date(securityState.pin.blocked_until).toISOString();
+        const blockedTemplate = await getNotificationTemplate(
+          phoneNumber,
+          NotificationEnum.pin_blocked
+        );
 
         return {
           ok: false,
           status: 'blocked',
           blocked_until: securityState.pin.blocked_until,
-          message: (await getNotificationTemplate(phoneNumber, NotificationEnum.pin_blocked))
-            ?.message
+          message: blockedTemplate?.message.replace('[BLOCKED_UNTIL]', blockedUntilIso)
         };
       }
 
@@ -316,7 +318,6 @@ export const securityService = {
       const isValid = secureCompareHex(expectedHash, securityState.pin.hash);
 
       if (isValid) {
-        // Reset failed attempts
         await mongoSecurityService.resetPinFailedAttempts(phoneNumber);
 
         return {
@@ -331,7 +332,6 @@ export const securityService = {
       // PIN is incorrect - increment failed attempts
       const { failed_attempts } = await mongoSecurityService.incrementPinFailedAttempt(phoneNumber);
 
-      // Log failed attempt
       await mongoSecurityEventsService.logSecurityEvent({
         user_id: phoneNumber,
         event_type: 'PIN_VERIFY_FAILED',
@@ -344,7 +344,6 @@ export const securityService = {
         const blockedUntil = new Date(now.getTime() + SECURITY_PIN_BLOCK_MINUTES * 60 * 1000);
         await mongoSecurityService.setPinBlockedUntil(phoneNumber, blockedUntil);
 
-        // Log blocked event
         await mongoSecurityEventsService.logSecurityEvent({
           user_id: phoneNumber,
           event_type: 'PIN_BLOCKED',
@@ -352,28 +351,33 @@ export const securityService = {
           metadata: { blocked_until: blockedUntil.toISOString() }
         });
 
+        const blockedTemplate = await getNotificationTemplate(
+          phoneNumber,
+          NotificationEnum.pin_blocked
+        );
+
         return {
           ok: false,
           status: 'blocked',
           blocked_until: blockedUntil,
-          message: (
-            await getNotificationTemplate(
-              phoneNumber,
-              NotificationEnum.pin_invalid_remaining_attempts
-            )
-          ).message.replace('[BLOCKED_UNTIL]', blockedUntil.toISOString())
+          message: blockedTemplate?.message.replace('[BLOCKED_UNTIL]', blockedUntil.toISOString())
         };
       }
 
       const remainingAttempts = SECURITY_PIN_MAX_FAILED_ATTEMPTS - failed_attempts;
+      const invalidPinTemplate = await getNotificationTemplate(
+        phoneNumber,
+        NotificationEnum.pin_invalid_remaining_attempts
+      );
 
       return {
         ok: false,
         status: 'active',
         remaining_attempts: remainingAttempts,
-        message: (
-          await getNotificationTemplate(phoneNumber, NotificationEnum.pin_internal_error)
-        ).message.replace('[REMAINING_ATTEMPTS]', remainingAttempts.toString())
+        message: invalidPinTemplate?.message.replace(
+          '[REMAINING_ATTEMPTS]',
+          remainingAttempts.toString()
+        )
       };
     } catch (error: unknown) {
       Logger.error('securityService', 'verifyPin', 'Failed to verify PIN', error);

--- a/src/services/securityService.ts
+++ b/src/services/securityService.ts
@@ -287,7 +287,8 @@ export const securityService = {
         return {
           ok: false,
           status: 'not_set',
-          message: 'PIN verification error: PIN is not set'
+          message:
+            'Security PIN is not set. Please set it in your ChatterPay profile on the web dashboard.'
         };
       }
 
@@ -297,11 +298,15 @@ export const securityService = {
         securityState.pin.blocked_until > now &&
         securityState.pin.status === 'blocked'
       ) {
+        const blockedUntilIso = new Date(securityState.pin.blocked_until).toISOString();
+
         return {
           ok: false,
           status: 'blocked',
           blocked_until: securityState.pin.blocked_until,
-          message: 'PIN verification error: PIN is blocked'
+          message:
+            `Too many incorrect attempts. Your Security PIN is temporarily locked. ` +
+            `Please try again later. (Unlocks at: ${blockedUntilIso})`
         };
       }
 
@@ -317,7 +322,7 @@ export const securityService = {
         return {
           ok: true,
           status: 'active',
-          message: 'PIN verified successfully'
+          message: 'PIN verified successfully.'
         };
       }
 
@@ -349,7 +354,9 @@ export const securityService = {
           ok: false,
           status: 'blocked',
           blocked_until: blockedUntil,
-          message: 'PIN verification error: invalid PIN. PIN blocked.'
+          message:
+            `Too many incorrect attempts. Your Security PIN is temporarily locked. ` +
+            `Please try again later. (Unlocks at: ${blockedUntil.toISOString()})`
         };
       }
 
@@ -359,7 +366,7 @@ export const securityService = {
         ok: false,
         status: 'active',
         remaining_attempts: remainingAttempts,
-        message: `PIN verification error: invalid PIN. Remaining attempts: ${remainingAttempts}`
+        message: `Incorrect PIN. You have ${remainingAttempts} attempt(s) left.`
       };
     } catch (error: unknown) {
       Logger.error('securityService', 'verifyPin', 'Failed to verify PIN', error);

--- a/src/services/securityService.ts
+++ b/src/services/securityService.ts
@@ -15,11 +15,12 @@ import type {
   SecurityEventChannel,
   SecurityEventType
 } from '../models/securityEventModel';
-import type { LocalizedContentType } from '../models/templateModel';
+import { type LocalizedContentType, NotificationEnum } from '../models/templateModel';
 import { mongoSecurityEventsService } from './mongo/mongoSecurityEventsService';
 import { mongoSecurityService, type RecoveryQuestionRecord } from './mongo/mongoSecurityService';
 import { mongoTemplateService, templateEnum } from './mongo/mongoTemplateService';
 import { mongoUserService } from './mongo/mongoUserService';
+import { getNotificationTemplate } from './notificationService';
 
 const HMAC_ALGORITHM = 'sha256';
 const DEFAULT_SALT_BYTES = 16;
@@ -287,8 +288,8 @@ export const securityService = {
         return {
           ok: false,
           status: 'not_set',
-          message:
-            'Security PIN is not set. Please set it in your ChatterPay profile on the web dashboard.'
+          message: (await getNotificationTemplate(phoneNumber, NotificationEnum.pin_not_set))
+            ?.message
         };
       }
 
@@ -304,9 +305,8 @@ export const securityService = {
           ok: false,
           status: 'blocked',
           blocked_until: securityState.pin.blocked_until,
-          message:
-            `Too many incorrect attempts. Your Security PIN is temporarily locked. ` +
-            `Please try again later. (Unlocks at: ${blockedUntilIso})`
+          message: (await getNotificationTemplate(phoneNumber, NotificationEnum.pin_blocked))
+            ?.message
         };
       }
 
@@ -322,7 +322,9 @@ export const securityService = {
         return {
           ok: true,
           status: 'active',
-          message: 'PIN verified successfully.'
+          message: (
+            await getNotificationTemplate(phoneNumber, NotificationEnum.pin_verified_success)
+          )?.message
         };
       }
 
@@ -354,9 +356,12 @@ export const securityService = {
           ok: false,
           status: 'blocked',
           blocked_until: blockedUntil,
-          message:
-            `Too many incorrect attempts. Your Security PIN is temporarily locked. ` +
-            `Please try again later. (Unlocks at: ${blockedUntil.toISOString()})`
+          message: (
+            await getNotificationTemplate(
+              phoneNumber,
+              NotificationEnum.pin_invalid_remaining_attempts
+            )
+          )?.message
         };
       }
 
@@ -373,7 +378,8 @@ export const securityService = {
       return {
         ok: false,
         status: 'active',
-        message: 'PIN verification error: internal error'
+        message: (await getNotificationTemplate(phoneNumber, NotificationEnum.pin_internal_error))
+          ?.message
       };
     }
   },

--- a/src/services/securityService.ts
+++ b/src/services/securityService.ts
@@ -361,7 +361,7 @@ export const securityService = {
               phoneNumber,
               NotificationEnum.pin_invalid_remaining_attempts
             )
-          )?.message
+          ).message.replace('[BLOCKED_UNTIL]', blockedUntil.toISOString())
         };
       }
 
@@ -371,7 +371,9 @@ export const securityService = {
         ok: false,
         status: 'active',
         remaining_attempts: remainingAttempts,
-        message: `Incorrect PIN. You have ${remainingAttempts} attempt(s) left.`
+        message: (
+          await getNotificationTemplate(phoneNumber, NotificationEnum.pin_internal_error)
+        ).message.replace('[REMAINING_ATTEMPTS]', remainingAttempts.toString())
       };
     } catch (error: unknown) {
       Logger.error('securityService', 'verifyPin', 'Failed to verify PIN', error);

--- a/src/services/securityService.ts
+++ b/src/services/securityService.ts
@@ -273,7 +273,8 @@ export const securityService = {
    * @param pin - PIN provided by the user (plain text).
    * @param channel - Source channel for auditing ("bot" | "frontend" | "unknown").
    * @returns VerifyPinResult Verification outcome including status, message, and optional lock/attempt info.
-   */ verifyPin: async (
+   */
+  verifyPin: async (
     phoneNumber: string,
     pin: string,
     channel?: string
@@ -298,17 +299,25 @@ export const securityService = {
         securityState.pin.blocked_until > now &&
         securityState.pin.status === 'blocked'
       ) {
-        const blockedUntilIso = new Date(securityState.pin.blocked_until).toISOString();
         const blockedTemplate = await getNotificationTemplate(
           phoneNumber,
           NotificationEnum.pin_blocked
+        );
+        const remainingBlockMinutes = Math.max(
+          1,
+          Math.ceil(
+            (new Date(securityState.pin.blocked_until).getTime() - now.getTime()) / (60 * 1000)
+          )
         );
 
         return {
           ok: false,
           status: 'blocked',
           blocked_until: securityState.pin.blocked_until,
-          message: blockedTemplate?.message.replace('[BLOCKED_UNTIL]', blockedUntilIso)
+          message: blockedTemplate?.message.replace(
+            '[BLOCK_MINUTES]',
+            remainingBlockMinutes.toString()
+          )
         };
       }
 
@@ -360,7 +369,10 @@ export const securityService = {
           ok: false,
           status: 'blocked',
           blocked_until: blockedUntil,
-          message: blockedTemplate?.message.replace('[BLOCKED_UNTIL]', blockedUntil.toISOString())
+          message: blockedTemplate?.message.replace(
+            '[BLOCK_MINUTES]',
+            SECURITY_PIN_BLOCK_MINUTES.toString()
+          )
         };
       }
 

--- a/test/models/templateModel.test.ts
+++ b/test/models/templateModel.test.ts
@@ -1,279 +1,337 @@
 import mongoose from 'mongoose';
-import { describe, expect, it } from 'vitest';
+import { expect, it } from 'vitest';
 
 import {
-  type ITemplateSchema,
-  type NotificationEnum,
-  type NotificationTemplateType,
+  ITemplateSchema,
+  NotificationEnum,
+  NotificationTemplateType,
   TemplateType
 } from '../../src/models/templateModel';
 
-describe('Template Model', () => {
-  it('should create and save a Template document successfully', async () => {
-    type TestTemplateSchema = Partial<ITemplateSchema>;
+it('should create and save a Template document successfully', async () => {
+  type TestTemplateSchema = Partial<ITemplateSchema>;
 
-    const validTemplate: TestTemplateSchema = {
-      notifications: {
-        incoming_transfer: {
-          title: {
-            en: 'Transfer completed',
-            es: 'Transferencia completada',
-            pt: 'Transferência concluída'
-          },
-          message: {
-            en: 'Your transfer was successful.',
-            es: 'Tu transferencia fue exitosa.',
-            pt: 'Sua transferência foi bem-sucedida.'
-          }
+  const validTemplate: TestTemplateSchema = {
+    notifications: {
+      incoming_transfer: {
+        title: {
+          en: 'Transfer completed',
+          es: 'Transferencia completada',
+          pt: 'Transferência concluída'
         },
-        incoming_transfer_w_note: {
-          title: {
-            en: 'Transfer completed',
-            es: 'Transferencia completada',
-            pt: 'Transferência concluída'
-          },
-          message: {
-            en: 'Your transfer was successful.',
-            es: 'Tu transferencia fue exitosa.',
-            pt: 'Sua transferência foi bem-sucedida.'
-          }
+        message: {
+          en: 'Your transfer was successful.',
+          es: 'Tu transferencia fue exitosa.',
+          pt: 'Sua transferência foi bem-sucedida.'
+        }
+      },
+      incoming_transfer_w_note: {
+        title: {
+          en: 'Transfer completed',
+          es: 'Transferencia completada',
+          pt: 'Transferência concluída'
         },
-        incoming_transfer_external: {
-          title: {
-            en: 'External Transfer completed',
-            es: 'Transferencia externa completada',
-            pt: 'Transferência exerna concluída'
-          },
-          message: {
-            en: 'Your transfer was successful.',
-            es: 'Tu transferencia fue exitosa.',
-            pt: 'Sua transferência foi bem-sucedida.'
-          }
+        message: {
+          en: 'Your transfer was successful.',
+          es: 'Tu transferencia fue exitosa.',
+          pt: 'Sua transferência foi bem-sucedida.'
+        }
+      },
+      incoming_transfer_external: {
+        title: {
+          en: 'External Transfer completed',
+          es: 'Transferencia externa completada',
+          pt: 'Transferência exerna concluída'
         },
-        swap: {
-          title: { en: 'Swap completed', es: 'Intercambio completado', pt: 'Troca concluída' },
-          message: {
-            en: 'Your swap was successful.',
-            es: 'Tu intercambio fue exitoso.',
-            pt: 'Sua troca foi bem-sucedida.'
-          }
+        message: {
+          en: 'Your transfer was successful.',
+          es: 'Tu transferencia fue exitosa.',
+          pt: 'Sua transferência foi bem-sucedida.'
+        }
+      },
+      swap: {
+        title: { en: 'Swap completed', es: 'Intercambio completado', pt: 'Troca concluída' },
+        message: {
+          en: 'Your swap was successful.',
+          es: 'Tu intercambio fue exitoso.',
+          pt: 'Sua troca foi bem-sucedida.'
+        }
+      },
+      mint: {
+        title: { en: 'Minting completed', es: 'Creación completada', pt: 'Criação concluída' },
+        message: {
+          en: 'Your minting was successful.',
+          es: 'Tu creación fue exitosa.',
+          pt: 'Sua criação foi bem-sucedida.'
+        }
+      },
+      outgoing_transfer: {
+        title: {
+          en: 'Outgoing Transfer',
+          es: 'Transferencia Saliente',
+          pt: 'Transferência de Saída'
         },
-        mint: {
-          title: { en: 'Minting completed', es: 'Creación completada', pt: 'Criação concluída' },
-          message: {
-            en: 'Your minting was successful.',
-            es: 'Tu creación fue exitosa.',
-            pt: 'Sua criação foi bem-sucedida.'
-          }
+        message: {
+          en: 'Your transfer is on the way.',
+          es: 'Tu transferencia está en camino.',
+          pt: 'Sua transferência está a caminho.'
+        }
+      },
+      wallet_creation: {
+        title: { en: 'Wallet Created', es: 'Billetera Creada', pt: 'Carteira Criada' },
+        message: {
+          en: 'Your wallet has been created successfully.',
+          es: 'Tu billetera ha sido creada con éxito.',
+          pt: 'Sua carteira foi criada com sucesso.'
+        }
+      },
+      wallet_already_exists: {
+        title: { en: 'Wallet Created', es: 'Billetera Creada', pt: 'Carteira Criada' },
+        message: {
+          en: 'Your wallet has been created successfully.',
+          es: 'Tu billetera ha sido creada con éxito.',
+          pt: 'Sua carteira foi criada com sucesso.'
+        }
+      },
+      user_balance_not_enough: {
+        title: { en: 'Insufficient Balance', es: 'Saldo Insuficiente', pt: 'Saldo Insuficiente' },
+        message: {
+          en: 'You do not have enough balance.',
+          es: 'No tienes saldo suficiente.',
+          pt: 'Você não tem saldo suficiente.'
+        }
+      },
+      no_valid_blockchain_conditions: {
+        title: {
+          en: 'Invalid Blockchain Conditions',
+          es: 'Condiciones de Blockchain Inválidas',
+          pt: 'Condições de Blockchain Inválidas'
         },
-        outgoing_transfer: {
-          title: {
-            en: 'Outgoing Transfer',
-            es: 'Transferencia Saliente',
-            pt: 'Transferência de Saída'
-          },
-          message: {
-            en: 'Your transfer is on the way.',
-            es: 'Tu transferencia está en camino.',
-            pt: 'Sua transferência está a caminho.'
-          }
+        message: {
+          en: 'Blockchain conditions are not met.',
+          es: 'No se cumplen las condiciones de blockchain.',
+          pt: 'As condições do blockchain não foram atendidas.'
+        }
+      },
+      internal_error: {
+        title: { en: 'Internal Error', es: 'Error Interno', pt: 'Erro Interno' },
+        message: {
+          en: 'An unexpected error occurred.',
+          es: 'Ocurrió un error inesperado.',
+          pt: 'Ocorreu um erro inesperado.'
+        }
+      },
+      concurrent_operation: {
+        title: {
+          en: 'Concurrent Operation',
+          es: 'Operación Concurrente',
+          pt: 'Operação Concorrente'
         },
-        wallet_creation: {
-          title: { en: 'Wallet Created', es: 'Billetera Creada', pt: 'Carteira Criada' },
-          message: {
-            en: 'Your wallet has been created successfully.',
-            es: 'Tu billetera ha sido creada con éxito.',
-            pt: 'Sua carteira foi criada com sucesso.'
-          }
+        message: {
+          en: 'Another operation is in progress.',
+          es: 'Otra operación está en progreso.',
+          pt: 'Outra operação está em andamento.'
+        }
+      },
+      daily_limit_reached: {
+        title: {
+          en: 'ChatterPay: Daily Limit Reached 🌟',
+          es: 'ChatterPay: Límite diario alcanzado 🌟',
+          pt: 'ChatterPay: Limite diário atingido 🌟'
         },
-        wallet_already_exists: {
-          title: { en: 'Wallet Created', es: 'Billetera Creada', pt: 'Carteira Criada' },
-          message: {
-            en: 'Your wallet has been created successfully.',
-            es: 'Tu billetera ha sido creada con éxito.',
-            pt: 'Sua carteira foi criada com sucesso.'
-          }
+        message: {
+          en: "You've reached the maximum number of daily operations allowed for this type of transaction. Please try again tomorrow. 🙌",
+          es: 'Has alcanzado la cantidad máxima diaria permitida para este tipo de operación. Por favor, inténtalo nuevamente mañana. 🙌',
+          pt: 'Você atingiu a quantidade máxima diária permitida para esse tipo de operação. Por favor, tente novamente amanhã. 🙌'
+        }
+      },
+      amount_outside_limits: {
+        title: {
+          en: 'ChatterPay - Operation Outside Limits 🚫',
+          es: 'ChatterPay - Operación fuera de los límites 🚫',
+          pt: 'ChatterPay - Operação fora dos limites 🚫'
         },
-        user_balance_not_enough: {
-          title: { en: 'Insufficient Balance', es: 'Saldo Insuficiente', pt: 'Saldo Insuficiente' },
-          message: {
-            en: 'You do not have enough balance.',
-            es: 'No tienes saldo suficiente.',
-            pt: 'Você não tem saldo suficiente.'
-          }
+        message: {
+          en: "The amount you're trying to operate is outside the limits of this operation (min: [LIMIT_MIN], max: [LIMIT_MAX]). Please try again with a valid amount. 🙅‍♂️",
+          es: 'El monto que intentas operar está fuera de los límites de esta operación (min: [LIMIT_MIN], max: [LIMIT_MAX]). Por favor, inténtalo nuevamente con un monto válido. 🙅‍♂️',
+          pt: 'O valor que você está tentando operar está fora dos limites desta operação (min: [LIMIT_MIN], max: [LIMIT_MAX]). Tente novamente com um valor válido. 🙅‍♂️'
+        }
+      },
+      aave_supply_created: {
+        title: {
+          en: 'Chatterpay: Savings created successfully!',
+          es: 'Chatterpay: ✅ Ahorro creado con éxito',
+          pt: 'Chatterpay: Poupança criada com sucesso!'
         },
-        no_valid_blockchain_conditions: {
-          title: {
-            en: 'Invalid Blockchain Conditions',
-            es: 'Condiciones de Blockchain Inválidas',
-            pt: 'Condições de Blockchain Inválidas'
-          },
-          message: {
-            en: 'Blockchain conditions are not met.',
-            es: 'No se cumplen las condiciones de blockchain.',
-            pt: 'As condições do blockchain não foram atendidas.'
-          }
+        message: {
+          en: '✅ You have successfully deposited [AMOUNT] [TOKEN] to start earning interest! 🎉\n\nCheck the transaction details here: [EXPLORER]/tx/[TX_HASH]',
+          es: '✅ ¡Has depositado correctamente [AMOUNT] [TOKEN] para empezar a generar intereses! 🎉\n\nPodés ver los detalles de la transacción aquí:\n[EXPLORER]/tx/[TX_HASH]',
+          pt: '✅ Você depositou [AMOUNT] [TOKEN] com sucesso para começar a ganhar juros! 🎉\n\nConfira os detalhes da transação aqui:\n[EXPLORER]/tx/[TX_HASH]'
+        }
+      },
+      aave_supply_info: {
+        title: {
+          en: 'Chatterpay: Your Savings Info',
+          es: 'Chatterpay: 💰 Información de tu Ahorro',
+          pt: 'Chatterpay: Informações da sua Poupança'
         },
-        internal_error: {
-          title: { en: 'Internal Error', es: 'Error Interno', pt: 'Erro Interno' },
-          message: {
-            en: 'An unexpected error occurred.',
-            es: 'Ocurrió un error inesperado.',
-            pt: 'Ocorreu um erro inesperado.'
-          }
+        message: {
+          en: '📊 Current savings status:\n• Deposited amount: [ATOKEN_BALANCE] [ATOKEN_SYMBOL]\n• Annual interest rate (APY): [SUPPLY_APY]%\n\n✨ Your funds keep earning interest automatically.',
+          es: '📊 Estado actual de tu ahorro:\n• Monto depositado: [ATOKEN_BALANCE] [ATOKEN_SYMBOL]\n• Tasa de interés anual (APY): [SUPPLY_APY]%\n\n✨ Tu dinero sigue generando intereses automáticamente.',
+          pt: '📊 Status atual da sua poupança:\n• Quantia depositada: [ATOKEN_BALANCE] [ATOKEN_SYMBOL]\n• Taxa de juros anual (APY): [SUPPLY_APY]%\n\n✨ Seu dinheiro continua gerando juros automaticamente.'
+        }
+      },
+      aave_supply_info_no_data: {
+        title: {
+          en: 'Chatterpay: Your Savings Info',
+          es: 'Chatterpay: 💰 Información de tu Ahorro',
+          pt: 'Chatterpay: Informações da sua Poupança'
         },
-        concurrent_operation: {
-          title: {
-            en: 'Concurrent Operation',
-            es: 'Operación Concurrente',
-            pt: 'Operação Concorrente'
-          },
-          message: {
-            en: 'Another operation is in progress.',
-            es: 'Otra operación está en progreso.',
-            pt: 'Outra operação está em andamento.'
-          }
+        message: {
+          en: 'ℹ️ We couldn’t find information about your savings at this moment.',
+          es: 'ℹ️ No encontramos información de tu ahorro en este momento.',
+          pt: 'ℹ️ Não encontramos informações da sua poupança neste momento.'
+        }
+      },
+      aave_supply_modified: {
+        title: {
+          en: 'Chatterpay: Savings withdrawal completed',
+          es: 'Chatterpay: ✅ Retiro de ahorro completado',
+          pt: 'Chatterpay: Retirada de poupança concluída'
         },
-        daily_limit_reached: {
-          title: {
-            en: 'ChatterPay: Daily Limit Reached 🌟',
-            es: 'ChatterPay: Límite diario alcanzado 🌟',
-            pt: 'ChatterPay: Limite diário atingido 🌟'
-          },
-          message: {
-            en: "You've reached the maximum number of daily operations allowed for this type of transaction. Please try again tomorrow. 🙌",
-            es: 'Has alcanzado la cantidad máxima diaria permitida para este tipo de operación. Por favor, inténtalo nuevamente mañana. 🙌',
-            pt: 'Você atingiu a quantidade máxima diária permitida para esse tipo de operação. Por favor, tente novamente amanhã. 🙌'
-          }
+        message: {
+          en: '✅ You successfully withdrew [AMOUNT] [TOKEN] from your interest-bearing account. 🎉\n\nCheck the transaction details here:\n[EXPLORER]/tx/[TX_HASH]',
+          es: '✅ Has retirado correctamente [AMOUNT] [TOKEN] de tu cuenta con intereses. 🎉\n\nPodés ver los detalles de la transacción aquí:\n[EXPLORER]/tx/[TX_HASH]',
+          pt: '✅ Você retirou com sucesso [AMOUNT] [TOKEN] da sua conta com juros. 🎉\n\nConfira os detalhes da transação aqui:\n[EXPLORER]/tx/[TX_HASH]'
+        }
+      },
+      chatterpoints_operation: {
+        title: {
+          en: 'ChatterPay: You earned ChatterPoints! 🎯',
+          es: 'ChatterPay: ¡Ganaste ChatterPoints! 🎯',
+          pt: 'ChatterPay: Você ganhou ChatterPoints! 🎯'
         },
-        amount_outside_limits: {
-          title: {
-            en: 'ChatterPay - Operation Outside Limits 🚫',
-            es: 'ChatterPay - Operación fuera de los límites 🚫',
-            pt: 'ChatterPay - Operação fora dos limites 🚫'
-          },
-          message: {
-            en: "The amount you're trying to operate is outside the limits of this operation (min: [LIMIT_MIN], max: [LIMIT_MAX]). Please try again with a valid amount. 🙅‍♂️",
-            es: 'El monto que intentas operar está fuera de los límites de esta operación (min: [LIMIT_MIN], max: [LIMIT_MAX]). Por favor, inténtalo nuevamente con un monto válido. 🙅‍♂️',
-            pt: 'O valor que você está tentando operar está fora dos limites desta operação (min: [LIMIT_MIN], max: [LIMIT_MAX]). Tente novamente com um valor válido. 🙅‍♂️'
-          }
+        message: {
+          en: 'Con esta operación sumaste [POINTS] ChatterPoints! 🥳',
+          es: '¡Con esta operación sumaste [POINTS] ChatterPoints! 🥳',
+          pt: 'Com esta operação você ganhou [POINTS] ChatterPoints! 🥳'
+        }
+      },
+      cross_chain_disabled: {
+        title: {
+          en: 'Cross-chain transfers disabled',
+          es: 'Transferencias cross-chain deshabilitadas',
+          pt: 'Transferências cross-chain desativadas'
         },
-        aave_supply_created: {
-          title: {
-            en: 'Chatterpay: Savings created successfully!',
-            es: 'Chatterpay: ✅ Ahorro creado con éxito',
-            pt: 'Chatterpay: Poupança criada com sucesso!'
-          },
-          message: {
-            en: '✅ You have successfully deposited [AMOUNT] [TOKEN] to start earning interest! 🎉\n\nCheck the transaction details here: [EXPLORER]/tx/[TX_HASH]',
-            es: '✅ ¡Has depositado correctamente [AMOUNT] [TOKEN] para empezar a generar intereses! 🎉\n\nPodés ver los detalles de la transacción aquí:\n[EXPLORER]/tx/[TX_HASH]',
-            pt: '✅ Você depositou [AMOUNT] [TOKEN] com sucesso para começar a ganhar juros! 🎉\n\nConfira os detalhes da transação aqui:\n[EXPLORER]/tx/[TX_HASH]'
-          }
+        message: {
+          en: 'Cross-chain transfers are currently disabled.',
+          es: 'Las transferencias cross-chain están actualmente deshabilitadas.',
+          pt: 'As transferências cross-chain estão atualmente desativadas.'
+        }
+      },
+      pin_not_set: {
+        title: {
+          en: 'ChatterPay: Set your Security PIN',
+          es: 'ChatterPay: Configurá tu PIN de seguridad',
+          pt: 'ChatterPay: Defina seu PIN de segurança'
         },
-        aave_supply_info: {
-          title: {
-            en: 'Chatterpay: Your Savings Info',
-            es: 'Chatterpay: 💰 Información de tu Ahorro',
-            pt: 'Chatterpay: Informações da sua Poupança'
-          },
-          message: {
-            en: '📊 Current savings status:\n• Deposited amount: [ATOKEN_BALANCE] [ATOKEN_SYMBOL]\n• Annual interest rate (APY): [SUPPLY_APY]%\n\n✨ Your funds keep earning interest automatically.',
-            es: '📊 Estado actual de tu ahorro:\n• Monto depositado: [ATOKEN_BALANCE] [ATOKEN_SYMBOL]\n• Tasa de interés anual (APY): [SUPPLY_APY]%\n\n✨ Tu dinero sigue generando intereses automáticamente.',
-            pt: '📊 Status atual da sua poupança:\n• Quantia depositada: [ATOKEN_BALANCE] [ATOKEN_SYMBOL]\n• Taxa de juros anual (APY): [SUPPLY_APY]%\n\n✨ Seu dinheiro continua gerando juros automaticamente.'
-          }
+        message: {
+          en: 'Security PIN is not set. Please set it in your ChatterPay profile on the web dashboard.',
+          es: 'Tu PIN de seguridad no está configurado. Configuralo en tu perfil de ChatterPay en el panel web.',
+          pt: 'Seu PIN de segurança não está definido. Defina-o no seu perfil do ChatterPay no painel web.'
+        }
+      },
+      pin_invalid_remaining_attempts: {
+        title: {
+          en: 'ChatterPay: Incorrect Security PIN',
+          es: 'ChatterPay: PIN de seguridad incorrecto',
+          pt: 'ChatterPay: PIN de segurança incorreto'
         },
-        aave_supply_info_no_data: {
-          title: {
-            en: 'Chatterpay: Your Savings Info',
-            es: 'Chatterpay: 💰 Información de tu Ahorro',
-            pt: 'Chatterpay: Informações da sua Poupança'
-          },
-          message: {
-            en: 'ℹ️ We couldn’t find information about your savings at this moment.',
-            es: 'ℹ️ No encontramos información de tu ahorro en este momento.',
-            pt: 'ℹ️ Não encontramos informações da sua poupança neste momento.'
-          }
+        message: {
+          en: 'Incorrect PIN. You have [REMAINING_ATTEMPTS] attempt(s) left.',
+          es: 'PIN incorrecto. Te quedan [REMAINING_ATTEMPTS] intento(s).',
+          pt: 'PIN incorreto. Você tem [REMAINING_ATTEMPTS] tentativa(s) restante(s).'
+        }
+      },
+      pin_blocked: {
+        title: {
+          en: 'ChatterPay: Security PIN temporarily locked',
+          es: 'ChatterPay: PIN de seguridad bloqueado temporalmente',
+          pt: 'ChatterPay: PIN de segurança temporariamente bloqueado'
         },
-        aave_supply_modified: {
-          title: {
-            en: 'Chatterpay: Savings withdrawal completed',
-            es: 'Chatterpay: ✅ Retiro de ahorro completado',
-            pt: 'Chatterpay: Retirada de poupança concluída'
-          },
-          message: {
-            en: '✅ You successfully withdrew [AMOUNT] [TOKEN] from your interest-bearing account. 🎉\n\nCheck the transaction details here:\n[EXPLORER]/tx/[TX_HASH]',
-            es: '✅ Has retirado correctamente [AMOUNT] [TOKEN] de tu cuenta con intereses. 🎉\n\nPodés ver los detalles de la transacción aquí:\n[EXPLORER]/tx/[TX_HASH]',
-            pt: '✅ Você retirou com sucesso [AMOUNT] [TOKEN] da sua conta com juros. 🎉\n\nConfira os detalhes da transação aqui:\n[EXPLORER]/tx/[TX_HASH]'
-          }
+        message: {
+          en: 'Too many incorrect attempts. Your Security PIN is temporarily locked. Please try again later. (Unlocks at: [BLOCKED_UNTIL])',
+          es: 'Demasiados intentos incorrectos. Tu PIN de seguridad quedó bloqueado temporalmente. Volvé a intentar más tarde. (Se desbloquea: [BLOCKED_UNTIL])',
+          pt: 'Muitas tentativas incorretas. Seu PIN de segurança foi temporariamente bloqueado. Tente novamente mais tarde. (Desbloqueia em: [BLOCKED_UNTIL])'
+        }
+      },
+      pin_verified_success: {
+        title: {
+          en: 'ChatterPay: Security PIN verified',
+          es: 'ChatterPay: PIN de seguridad verificado',
+          pt: 'ChatterPay: PIN de segurança verificado'
         },
-        chatterpoints_operation: {
-          title: {
-            en: 'ChatterPay: You earned ChatterPoints! 🎯',
-            es: 'ChatterPay: ¡Ganaste ChatterPoints! 🎯',
-            pt: 'ChatterPay: Você ganhou ChatterPoints! 🎯'
-          },
-          message: {
-            en: 'Con esta operación sumaste [POINTS] ChatterPoints! 🥳',
-            es: '¡Con esta operación sumaste [POINTS] ChatterPoints! 🥳',
-            pt: 'Com esta operação você ganhou [POINTS] ChatterPoints! 🥳'
-          }
+        message: {
+          en: 'PIN verified successfully.',
+          es: 'PIN verificado correctamente.',
+          pt: 'PIN verificado com sucesso.'
+        }
+      },
+      pin_internal_error: {
+        title: {
+          en: 'ChatterPay: PIN verification failed',
+          es: 'ChatterPay: Falló la verificación del PIN',
+          pt: 'ChatterPay: Falha na verificação do PIN'
         },
-        cross_chain_disabled: {
-          title: {
-            en: 'Cross-chain transfers disabled',
-            es: 'Transferencias cross-chain deshabilitadas',
-            pt: 'Transferências cross-chain desativadas'
-          },
-          message: {
-            en: 'Cross-chain transfers are currently disabled.',
-            es: 'Las transferencias cross-chain están actualmente deshabilitadas.',
-            pt: 'As transferências cross-chain estão atualmente desativadas.'
-          }
+        message: {
+          en: 'PIN verification error: internal error',
+          es: 'Error al verificar el PIN: error interno.',
+          pt: 'Erro ao verificar o PIN: erro interno.'
         }
       }
-    };
+    }
+  };
 
-    const template = new TemplateType(validTemplate);
-    const savedTemplate = await template.save();
+  const template = new TemplateType(validTemplate);
+  const savedTemplate = await template.save();
 
-    expect(savedTemplate._id).toBeDefined();
-    expect(savedTemplate.notifications.incoming_transfer.title.en).toBe('Transfer completed');
+  expect(savedTemplate._id).toBeDefined();
+  expect(savedTemplate.notifications.incoming_transfer.title.en).toBe('Transfer completed');
 
-    expect(savedTemplate.notifications.aave_supply_created.title.es).toBe(
-      'Chatterpay: ✅ Ahorro creado con éxito'
-    );
-    expect(savedTemplate.notifications.aave_supply_info.message.es).toContain(
-      'Estado actual de tu ahorro'
-    );
-    expect(savedTemplate.notifications.aave_supply_modified.title.es).toBe(
-      'Chatterpay: ✅ Retiro de ahorro completado'
-    );
-  });
+  expect(savedTemplate.notifications.aave_supply_created.title.es).toBe(
+    'Chatterpay: ✅ Ahorro creado con éxito'
+  );
+  expect(savedTemplate.notifications.aave_supply_info.message.es).toContain(
+    'Estado actual de tu ahorro'
+  );
+  expect(savedTemplate.notifications.aave_supply_modified.title.es).toBe(
+    'Chatterpay: ✅ Retiro de ahorro completado'
+  );
+});
 
-  it('should fail to save without required fields', async () => {
-    type PartialNotifications = Partial<{
-      [key in NotificationEnum]: Partial<NotificationTemplateType>;
-    }>;
+it('should fail to save without required fields', async () => {
+  type PartialNotifications = Partial<{
+    [key in NotificationEnum]: Partial<NotificationTemplateType>;
+  }>;
 
-    type TestTemplateSchema = Omit<ITemplateSchema, 'notifications'> & {
-      notifications?: PartialNotifications;
-    };
+  type TestTemplateSchema = Omit<ITemplateSchema, 'notifications'> & {
+    notifications?: PartialNotifications;
+  };
 
-    const invalidTemplate = {
-      notifications: {
-        incoming_transfer: {
-          title: {
-            en: 'Transfer completed',
-            es: 'Transferencia completada',
-            pt: 'Transferência concluída'
-          }
-          // missing message field
+  const invalidTemplate = {
+    notifications: {
+      incoming_transfer: {
+        title: {
+          en: 'Transfer completed',
+          es: 'Transferencia completada',
+          pt: 'Transferência concluída'
         }
+        // missing message field
       }
-    } as TestTemplateSchema;
+    }
+  } as TestTemplateSchema;
 
-    const template = new TemplateType(invalidTemplate);
+  const template = new TemplateType(invalidTemplate);
 
-    await expect(template.save()).rejects.toThrow(mongoose.Error.ValidationError);
-  });
+  await expect(template.save()).rejects.toThrow(mongoose.Error.ValidationError);
 });

--- a/test/services/securityService.test.ts
+++ b/test/services/securityService.test.ts
@@ -43,7 +43,12 @@ describe('securityService', () => {
         aave_supply_info: mockNotification,
         aave_supply_info_no_data: mockNotification,
         chatterpoints_operation: mockNotification,
-        cross_chain_disabled: mockNotification
+        cross_chain_disabled: mockNotification,
+        pin_blocked: mockNotification,
+        pin_not_set: mockNotification,
+        pin_invalid_remaining_attempts: mockNotification,
+        pin_verified_success: mockNotification,
+        pin_internal_error: mockNotification
       },
       security_questions: {
         pet_name: {


### PR DESCRIPTION
### Changes

- Implemented multilingual Security PIN notification templates across the template model and verification flow.
- Updated PIN-related responses to use i18n-driven messages with runtime placeholder replacement.
- Aligned template selection for each PIN verification outcome.
- Extended the related model and security service tests to cover the new PIN templates.
- Adjusted the Biome configuration to disable the `useImportType` rule to prevent unwanted import rewrites.



### Related To

- #694