### PR TITLE
Fix: LiFi gas calculations

### DIFF
--- a/src/services/crossChainService.ts
+++ b/src/services/crossChainService.ts
@@ -127,114 +127,205 @@ export async function executeCrossChainTransfer(
       `Getting Li.Fi quote: ${sourceTokenSymbol} (Scroll) → ${destSymbol} (${destChain.name})`
     );
 
-    const quote = await getLifiQuote(
-      {
-        fromChain: networkConfig.chainId, // Scroll
-        toChain: destChain.id,
-        fromToken: sourceTokenAddress,
-        toToken: destToken.address,
-        fromAmount,
-        fromAddress: proxyAddress,
-        toAddress // Destination address on other chain
-      },
-      logKey
-    );
-
     // 4. Get ChatterPay ABI and Gas Price
     const chatterpayABI = await getChatterpayABI();
+    // NOTE: Use getGasPrice() instead of getFeeData().gasPrice because ethers.js v5
+    // hardcodes maxPriorityFeePerGas=1.5 gwei in getFeeData(), which massively overpays on L2s.
     const gasPrice = await provider.getGasPrice();
 
-    // 5. Check if approval is needed and execute
-    const erc20ABI = ['function allowance(address,address) view returns (uint256)'];
-    const tokenContract = new ethers.Contract(sourceTokenAddress, erc20ABI, provider);
-    const currentAllowance = await tokenContract.allowance(
-      proxyAddress,
-      quote.estimate.approvalAddress
-    );
-
     let approveTransactionHash = '';
+    let approvalDone = false;
 
-    if (currentAllowance.lt(fromAmount)) {
+    // Retry with increasing slippage: 1% → 2% → 5%
+    const SLIPPAGE_LEVELS = [0.01, 0.02, 0.05];
+
+    for (let attempt = 0; attempt < SLIPPAGE_LEVELS.length; attempt++) {
+      const slippage = SLIPPAGE_LEVELS[attempt];
+
       Logger.info(
         'executeCrossChainTransfer',
         logKey,
-        `Approving ${quote.estimate.approvalAddress} to spend tokens`
+        `Attempt ${attempt + 1}/${SLIPPAGE_LEVELS.length}, slippage: ${(slippage * 100).toFixed(1)}%`
       );
 
-      const approveABI = ['function approve(address,uint256) returns (bool)'];
-      const approveInterface = new ethers.utils.Interface(approveABI);
-      const approveData = approveInterface.encodeFunctionData('approve', [
-        quote.estimate.approvalAddress,
-        ethers.constants.MaxUint256
-      ]);
-
-      const chatterPayContract = new ethers.Contract(proxyAddress, chatterpayABI, backendSigner);
-
-      const approveTx = await chatterPayContract.execute(sourceTokenAddress, 0, approveData, {
-        gasLimit: 100000,
-        gasPrice
-      });
-
-      const approveReceipt = await approveTx.wait();
-      approveTransactionHash = approveReceipt.transactionHash;
-
-      if (approveReceipt.status !== 1) {
-        Logger.error(
+      let quote;
+      try {
+        quote = await getLifiQuote(
+          {
+            fromChain: networkConfig.chainId, // Scroll
+            toChain: destChain.id,
+            fromToken: sourceTokenAddress,
+            toToken: destToken.address,
+            fromAmount,
+            fromAddress: proxyAddress,
+            toAddress, // Destination address on other chain
+            slippage
+          },
+          logKey
+        );
+      } catch (quoteError) {
+        const quoteMsg = quoteError instanceof Error ? quoteError.message : String(quoteError);
+        Logger.warn(
           'executeCrossChainTransfer',
           logKey,
-          `Approval transaction failed. Tx: ${approveTransactionHash}`
+          `Quote failed (attempt ${attempt + 1}, slippage ${(slippage * 100).toFixed(1)}%): ${quoteMsg}`
         );
+
+        if (attempt < SLIPPAGE_LEVELS.length - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
         return {
           success: false,
-          error: 'Token approval transaction failed'
+          error: `Cross-chain quote failed after ${SLIPPAGE_LEVELS.length} attempts: ${quoteMsg}`
         };
       }
 
-      Logger.info('executeCrossChainTransfer', logKey, `Approval tx: ${approveTransactionHash}`);
-    }
+      // 5. Check if approval is needed (only on first attempt)
+      if (!approvalDone) {
+        const erc20ABI = ['function allowance(address,address) view returns (uint256)'];
+        const tokenContract = new ethers.Contract(sourceTokenAddress, erc20ABI, provider);
+        const currentAllowance = await tokenContract.allowance(
+          proxyAddress,
+          quote.estimate.approvalAddress
+        );
 
-    // 6. Execute the cross-chain transfer
-    Logger.info(
-      'executeCrossChainTransfer',
-      logKey,
-      `Executing cross-chain transfer via ${quote.tool}`
-    );
+        if (currentAllowance.lt(fromAmount)) {
+          Logger.info(
+            'executeCrossChainTransfer',
+            logKey,
+            `Approving ${quote.estimate.approvalAddress} to spend tokens`
+          );
 
-    const chatterPayContract = new ethers.Contract(proxyAddress, chatterpayABI, backendSigner);
+          const approveABI = ['function approve(address,uint256) returns (bool)'];
+          const approveInterface = new ethers.utils.Interface(approveABI);
+          const approveData = approveInterface.encodeFunctionData('approve', [
+            quote.estimate.approvalAddress,
+            ethers.constants.MaxUint256
+          ]);
 
-    const bridgeTx = await chatterPayContract.execute(
-      quote.transactionRequest.to,
-      quote.transactionRequest.value || 0,
-      quote.transactionRequest.data,
-      {
-        gasLimit: 800000,
-        gasPrice
+          const chatterPayApprove = new ethers.Contract(proxyAddress, chatterpayABI, backendSigner);
+          const approveTx = await chatterPayApprove.execute(sourceTokenAddress, 0, approveData, {
+            gasLimit: 100000,
+            gasPrice
+          });
+
+          const approveReceipt = await approveTx.wait();
+          approveTransactionHash = approveReceipt.transactionHash;
+
+          if (approveReceipt.status !== 1) {
+            return {
+              success: false,
+              error: 'Token approval transaction failed'
+            };
+          }
+
+          Logger.info(
+            'executeCrossChainTransfer',
+            logKey,
+            `Approval tx: ${approveTransactionHash}`
+          );
+        }
+        approvalDone = true;
       }
-    );
 
-    const bridgeReceipt = await bridgeTx.wait();
+      // 6. Execute the cross-chain transfer
+      // Use LiFi's gas estimate + 20% buffer for the execute() wrapper overhead
+      const lifiGasLimit = quote.transactionRequest.gasLimit
+        ? Math.ceil(Number(quote.transactionRequest.gasLimit) * 1.2)
+        : 800000;
 
-    if (bridgeReceipt.status !== 1) {
+      const chatterPayContract = new ethers.Contract(proxyAddress, chatterpayABI, backendSigner);
+
+      // Simulate first to avoid burning gas on reverts
+      const callData = chatterPayContract.interface.encodeFunctionData('execute', [
+        quote.transactionRequest.to,
+        quote.transactionRequest.value || 0,
+        quote.transactionRequest.data
+      ]);
+
+      try {
+        await provider.call({
+          to: proxyAddress,
+          data: callData,
+          from: backendSigner.address,
+          gasLimit: lifiGasLimit
+        });
+      } catch (simError) {
+        const simMsg = simError instanceof Error ? simError.message : String(simError);
+        Logger.warn(
+          'executeCrossChainTransfer',
+          logKey,
+          `Simulation failed (attempt ${attempt + 1}, slippage ${(slippage * 100).toFixed(1)}%): ${simMsg}`
+        );
+
+        // If more slippage levels to try, continue; otherwise throw
+        if (attempt < SLIPPAGE_LEVELS.length - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return {
+          success: false,
+          error: `Cross-chain simulation failed after ${SLIPPAGE_LEVELS.length} attempts: ${simMsg}`
+        };
+      }
+
+      Logger.info(
+        'executeCrossChainTransfer',
+        logKey,
+        `Executing cross-chain transfer via ${quote.tool}, gasLimit: ${lifiGasLimit}, slippage: ${(slippage * 100).toFixed(1)}%`
+      );
+
+      const bridgeTx = await chatterPayContract.execute(
+        quote.transactionRequest.to,
+        quote.transactionRequest.value || 0,
+        quote.transactionRequest.data,
+        {
+          gasLimit: lifiGasLimit,
+          gasPrice
+        }
+      );
+
+      const bridgeReceipt = await bridgeTx.wait();
+
+      if (bridgeReceipt.status !== 1) {
+        Logger.warn(
+          'executeCrossChainTransfer',
+          logKey,
+          `Bridge tx reverted (attempt ${attempt + 1}). Tx: ${bridgeReceipt.transactionHash}`
+        );
+
+        if (attempt < SLIPPAGE_LEVELS.length - 1) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          continue;
+        }
+        return {
+          success: false,
+          error: 'Cross-chain transfer transaction failed after all attempts'
+        };
+      }
+
+      Logger.info(
+        'executeCrossChainTransfer',
+        logKey,
+        `Cross-chain transfer initiated. Tx: ${bridgeReceipt.transactionHash}`
+      );
+
       return {
-        success: false,
-        error: 'Cross-chain transfer transaction failed'
+        success: true,
+        transactionHash: bridgeReceipt.transactionHash,
+        bridgeDetails: {
+          tool: quote.tool,
+          estimatedToAmount: quote.estimate.toAmount,
+          destToken
+        }
       };
     }
 
-    Logger.info(
-      'executeCrossChainTransfer',
-      logKey,
-      `Cross-chain transfer initiated. Tx: ${bridgeReceipt.transactionHash}`
-    );
-
+    // Should not reach here, but just in case
     return {
-      success: true,
-      transactionHash: bridgeReceipt.transactionHash,
-      bridgeDetails: {
-        tool: quote.tool,
-        estimatedToAmount: quote.estimate.toAmount,
-        destToken
-      }
+      success: false,
+      error: 'Cross-chain transfer failed: exhausted all slippage attempts'
     };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/src/services/crossChainService.ts
+++ b/src/services/crossChainService.ts
@@ -140,8 +140,9 @@ export async function executeCrossChainTransfer(
       logKey
     );
 
-    // 4. Get ChatterPay ABI dynamically
+    // 4. Get ChatterPay ABI and Gas Price
     const chatterpayABI = await getChatterpayABI();
+    const gasPrice = await provider.getGasPrice();
 
     // 5. Check if approval is needed and execute
     const erc20ABI = ['function allowance(address,address) view returns (uint256)'];
@@ -170,7 +171,8 @@ export async function executeCrossChainTransfer(
       const chatterPayContract = new ethers.Contract(proxyAddress, chatterpayABI, backendSigner);
 
       const approveTx = await chatterPayContract.execute(sourceTokenAddress, 0, approveData, {
-        gasLimit: 100000
+        gasLimit: 100000,
+        gasPrice
       });
 
       const approveReceipt = await approveTx.wait();
@@ -197,8 +199,6 @@ export async function executeCrossChainTransfer(
       logKey,
       `Executing cross-chain transfer via ${quote.tool}`
     );
-
-    const gasPrice = await provider.getGasPrice();
 
     const chatterPayContract = new ethers.Contract(proxyAddress, chatterpayABI, backendSigner);
 

--- a/src/services/crossChainService.ts
+++ b/src/services/crossChainService.ts
@@ -198,8 +198,7 @@ export async function executeCrossChainTransfer(
       `Executing cross-chain transfer via ${quote.tool}`
     );
 
-    const feeData = await provider.getFeeData();
-    const gasPrice = feeData.gasPrice || ethers.utils.parseUnits('0.001', 'gwei');
+    const gasPrice = await provider.getGasPrice();
 
     const chatterPayContract = new ethers.Contract(proxyAddress, chatterpayABI, backendSigner);
 

--- a/src/services/lifi/lifiService.ts
+++ b/src/services/lifi/lifiService.ts
@@ -105,6 +105,16 @@ export function parseLifiError(error: unknown): LifiParsedError {
       };
     }
 
+    // 404 "No available quotes" can be transient (bridge temporarily unavailable)
+    if (status === 404) {
+      return {
+        isRecoverable: true,
+        shouldRetry: true,
+        errorCode: `CLIENT_ERROR_404`,
+        message: data?.message || 'No available quotes for the requested transfer'
+      };
+    }
+
     // Generic client error
     return {
       isRecoverable: false,

--- a/src/services/swapService.ts
+++ b/src/services/swapService.ts
@@ -1831,7 +1831,6 @@ export async function executeSwapSimple(
     );
 
     const gasPrice = await provider.getGasPrice();
-    Logger.debug('executeSwapSimple', logKey, `gasPrice: ${gasPrice.toString()}`);
     const signerAddress = await signer.getAddress();
 
     // 4) Ensure signer has gas for SWAP transaction
@@ -2052,13 +2051,7 @@ export async function executeSwapLiFi(
     // - The entryPointContract parameter passed into this function is unused here.
     const backendSigner = setupContractsResult.backPrincipal;
 
-    // Get current gas price from network (avoid overpaying)
     const gasPrice = await provider.getGasPrice();
-    Logger.info(
-      'executeSwapLiFi',
-      logKey,
-      `Using gas price: ${ethers.utils.formatUnits(gasPrice, 'gwei')} gwei`
-    );
 
     const chatterPayContract = new ethers.Contract(proxyAddress, chatterpayABI, backendSigner);
 
@@ -2112,6 +2105,10 @@ export async function executeSwapLiFi(
     const failedTools: string[] = []; // Track tools that failed during execution
 
     for (let swapAttempt = 1; swapAttempt <= MAX_SWAP_RETRIES; swapAttempt++) {
+      let lifiGasLimit = quote.transactionRequest.gasLimit
+        ? Math.ceil(Number(quote.transactionRequest.gasLimit) * 1.2)
+        : 800000;
+
       try {
         // Get fresh quote for retries (quotes expire quickly), excluding failed tools
         if (swapAttempt > 1) {
@@ -2147,10 +2144,15 @@ export async function executeSwapLiFi(
           );
         }
 
+        // Recalculate gas limit after fresh quote (may have changed)
+        lifiGasLimit = quote.transactionRequest.gasLimit
+          ? Math.ceil(Number(quote.transactionRequest.gasLimit) * 1.2)
+          : 800000;
+
         Logger.info(
           'executeSwapLiFi',
           logKey,
-          `Executing Li.Fi swap (attempt ${swapAttempt}, tool=${quote.tool})...`
+          `Executing Li.Fi swap (attempt ${swapAttempt}, tool=${quote.tool}, gasLimit=${lifiGasLimit})...`
         );
 
         // Simulate with eth_call first to catch revert reason
@@ -2165,7 +2167,7 @@ export async function executeSwapLiFi(
             to: proxyAddress,
             data: callData,
             from: backendSigner.address,
-            gasLimit: 800000
+            gasLimit: lifiGasLimit
           });
         } catch (simError) {
           const simErrorMsg =
@@ -2184,7 +2186,7 @@ export async function executeSwapLiFi(
           quote.transactionRequest.value || 0,
           quote.transactionRequest.data,
           {
-            gasLimit: 800000,
+            gasLimit: lifiGasLimit,
             gasPrice
           }
         );
@@ -2205,7 +2207,7 @@ export async function executeSwapLiFi(
                 to: proxyAddress,
                 data: callData,
                 from: backendSigner.address,
-                gasLimit: 800000
+                gasLimit: lifiGasLimit
               },
               swapReceipt.blockNumber
             );
@@ -2288,7 +2290,7 @@ export async function executeSwapLiFi(
                     to: proxyAddress,
                     data: replayCallData,
                     from: backendSigner.address,
-                    gasLimit: 800000
+                    gasLimit: lifiGasLimit
                   },
                   failedReceipt.blockNumber
                 );

--- a/src/services/swapService.ts
+++ b/src/services/swapService.ts
@@ -661,7 +661,7 @@ async function handleTokenApproval(
       approveGasLimit = ethers.BigNumber.from('100000');
     }
 
-    const feeData = await provider.getFeeData();
+    const gasPrice = await provider.getGasPrice();
     const signerAddress = await signer.getAddress();
 
     // Ensure funds for the APPROVAL transaction
@@ -670,13 +670,11 @@ async function handleTokenApproval(
       backendSigner,
       signerAddress,
       gasLimit: approveGasLimit,
-      gasPrice: feeData.gasPrice ?? undefined,
-      maxFeePerGas: feeData.maxFeePerGas ?? undefined,
+      gasPrice,
       bufferBps: 500,
       logKey
     });
 
-    const gasPrice = feeData.gasPrice || (await provider.getGasPrice());
     const approveTx = await signer.sendTransaction({
       to: recipient,
       data: approveCallData,
@@ -1832,8 +1830,8 @@ export async function executeSwapSimple(
       ethers.BigNumber.from('500000')
     );
 
-    const feeData = await provider.getFeeData();
-    Logger.debug('executeSwapSimple', logKey, `feeData: ${JSON.stringify(feeData)}`);
+    const gasPrice = await provider.getGasPrice();
+    Logger.debug('executeSwapSimple', logKey, `gasPrice: ${gasPrice.toString()}`);
     const signerAddress = await signer.getAddress();
 
     // 4) Ensure signer has gas for SWAP transaction
@@ -1842,8 +1840,7 @@ export async function executeSwapSimple(
       backendSigner,
       signerAddress,
       gasLimit,
-      gasPrice: feeData.gasPrice ?? undefined,
-      maxFeePerGas: feeData.maxFeePerGas ?? undefined,
+      gasPrice,
       bufferBps: 500,
       logKey
     });
@@ -1867,7 +1864,6 @@ export async function executeSwapSimple(
     Logger.debug('executeSwapSimple', logKey, `swapCallData: ${swapCallData}`);
 
     // 9) Send the swap transaction
-    const gasPrice = await provider.getGasPrice();
     const tx = await signer.sendTransaction({
       to: recipient,
       data: swapCallData,

--- a/src/services/swapService.ts
+++ b/src/services/swapService.ts
@@ -568,7 +568,7 @@ export async function ensureRecipientHasGas({
     `Top-up required: ${ethers.utils.formatEther(topUp)} ETH (shortfall ${ethers.utils.formatEther(shortfall)})`
   );
 
-  const topUpTx = await backendSigner.sendTransaction({ to: signerAddress, value: topUp });
+  const topUpTx = await backendSigner.sendTransaction({ to: signerAddress, value: topUp, gasPrice });
   const r = await topUpTx.wait();
 
   if (!r || r.status !== 1) {
@@ -2053,8 +2053,7 @@ export async function executeSwapLiFi(
     const backendSigner = setupContractsResult.backPrincipal;
 
     // Get current gas price from network (avoid overpaying)
-    const feeData = await provider.getFeeData();
-    const gasPrice = feeData.gasPrice || ethers.utils.parseUnits('0.001', 'gwei');
+    const gasPrice = await provider.getGasPrice();
     Logger.info(
       'executeSwapLiFi',
       logKey,

--- a/src/services/swapService.ts
+++ b/src/services/swapService.ts
@@ -568,7 +568,11 @@ export async function ensureRecipientHasGas({
     `Top-up required: ${ethers.utils.formatEther(topUp)} ETH (shortfall ${ethers.utils.formatEther(shortfall)})`
   );
 
-  const topUpTx = await backendSigner.sendTransaction({ to: signerAddress, value: topUp, gasPrice });
+  const topUpTx = await backendSigner.sendTransaction({
+    to: signerAddress,
+    value: topUp,
+    gasPrice
+  });
   const r = await topUpTx.wait();
 
   if (!r || r.status !== 1) {

--- a/test/services/lifi/lifiService.test.ts
+++ b/test/services/lifi/lifiService.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getLifiChains,
   getLifiToken,
+  parseLifiError,
   validateAddressForChainType
 } from '../../../src/services/lifi/lifiService';
 
@@ -116,6 +117,66 @@ describe('lifiService', () => {
       const token = await getLifiToken('eth', 'INVALID', '[test]');
 
       expect(token).toBeNull();
+    });
+  });
+
+  describe('parseLifiError', () => {
+    it('should treat 404 as retryable (transient "no quotes")', () => {
+      const axiosError = {
+        response: {
+          status: 404,
+          data: { message: 'No available quotes for the requested transfer' }
+        },
+        isAxiosError: true
+      };
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      const result = parseLifiError(axiosError);
+
+      expect(result.shouldRetry).toBe(true);
+      expect(result.isRecoverable).toBe(true);
+      expect(result.errorCode).toBe('CLIENT_ERROR_404');
+      expect(result.message).toBe('No available quotes for the requested transfer');
+    });
+
+    it('should treat 429 as retryable (rate limited)', () => {
+      const axiosError = {
+        response: { status: 429, data: {} },
+        isAxiosError: true
+      };
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      const result = parseLifiError(axiosError);
+
+      expect(result.shouldRetry).toBe(true);
+      expect(result.errorCode).toBe('RATE_LIMITED');
+    });
+
+    it('should treat 400 as non-retryable', () => {
+      const axiosError = {
+        response: { status: 400, data: { message: 'Bad request' } },
+        message: 'Request failed',
+        isAxiosError: true
+      };
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      const result = parseLifiError(axiosError);
+
+      expect(result.shouldRetry).toBe(false);
+      expect(result.isRecoverable).toBe(false);
+    });
+
+    it('should treat 5xx as retryable', () => {
+      const axiosError = {
+        response: { status: 502, data: { message: 'Bad Gateway' } },
+        isAxiosError: true
+      };
+      vi.mocked(axios.isAxiosError).mockReturnValue(true);
+
+      const result = parseLifiError(axiosError);
+
+      expect(result.shouldRetry).toBe(true);
+      expect(result.errorCode).toBe('SERVER_ERROR_502');
     });
   });
 


### PR DESCRIPTION
Closes: #698 

# Description
Based on recent testing of the new LiFI integration functionality, we found that swaps, and cross chain transfers use a very high gas price of 1.5gwei, driving transaction costs up to $0.70–$2.00. [1]

This resulted in approximately $17 in additional costs for the signer. 

The reason is that we were using a deprecated ethers.js function to perform the calculations, which returns a hardcoded value of 1.5 gwei.[2]

We also noticed during simulations with tenderly that some complex swap transactions ran out of gas and hit the gas limit [3]. The solution is to pass the gas limit through the LiFi quote instead of using a hardcoded value.

There are also other edge cases where quotes are missing due to low amounts or unusual routes, in which a more robust retry strategy that accounts for these cases should be implemented.

Once these issues are resolved, the efficiency of swaps should improve significantly, bringing the cost back to normal ($0.002528) [4] and reducing the error rate when requesting cross-chain or same-chain swaps. 

## Resources
1. Swaps before: https://scrollscan.com/tx/0x58afa96536801273c742621845a3cd3460d2fccbec5c0ddd14711340a5cc853d
2. Deprecated ethers.js function issue: https://github.com/ethers-io/ethers.js/issues/4952
3. Reverted TX due to gasLimit hit: https://scrollscan.com/tx/0xd6ce24b5212e3b5210dcecd403f0deb4a3a0b7c43a2df167d846b9a6586c6658
4. Successful transaction with updated gas: https://scrollscan.com//tx/0x7b79d5ea1ebdf30a5e3810dd418993ecf27635431e50091bf11ba0cff714508c