### PR TITLE
merge fix/20260809 into develop

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -234,7 +234,12 @@ export const ALCHEMY_VALIDATE_WEBHOOK_HEADER_API_KEY: boolean =
 export const TELEGRAM_WEBHOOK_PATH = '/telegram/webhook';
 
 export const CORS_ORIGINS_CHECK_POSTMAN: boolean = corsOriginsCheckPostman.toLowerCase() === 'true';
-export const CORS_ORIGINS_EXCEPTIONS: string = `/metadata/opensea,/favicon.ico,/docs,${TELEGRAM_WEBHOOK_PATH},${ALCHEMY_WEBHOOKS_PATH},/polymarket/terms`;
+// Paths exempt from the origin check. They must match the routes as registered in
+// `src/api/*.ts`, since the check compares against the full request path: the NFT
+// metadata entry read `/metadata/opensea` while the route is `/nft/metadata/opensea/:id`,
+// so it never matched and every request without an Origin header was rejected — which is
+// exactly how explorers, marketplaces and link previews fetch the tokenURI.
+export const CORS_ORIGINS_EXCEPTIONS: string = `/nft/metadata/opensea,/favicon.ico,/docs,${TELEGRAM_WEBHOOK_PATH},${ALCHEMY_WEBHOOKS_PATH},/polymarket/terms`;
 
 export const COINGECKO_API_BASE_URL = 'https://api.coingecko.com/api/v3/simple/price';
 export const TOKEN_IDS = ['usd-coin', 'tether', 'ethereum', 'bitcoin', 'wrapped-bitcoin', 'dai'];

--- a/src/controllers/swapController.ts
+++ b/src/controllers/swapController.ts
@@ -1,7 +1,11 @@
 import { ethers } from 'ethers';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { Logger } from '../helpers/loggerHelper';
-import { returnErrorResponse, returnSuccessResponse } from '../helpers/requestHelper';
+import {
+  returnErrorResponse,
+  returnErrorResponseAsSuccess,
+  returnSuccessResponse
+} from '../helpers/requestHelper';
 import { delaySeconds } from '../helpers/timeHelper';
 import { isValidPhoneNumber } from '../helpers/validationHelper';
 import { NotificationEnum } from '../models/templateModel';
@@ -113,7 +117,7 @@ export const swap = async (
     if (!request.body) {
       return await returnErrorResponse(
         'swap',
-        '',
+        logKey,
         reply,
         400,
         'You have to send a body with this request'
@@ -123,6 +127,8 @@ export const swap = async (
     const { channel_user_id, inputCurrency, outputCurrency, amount } = request.body;
     const lastBotMsgDelaySeconds = request.query?.lastBotMsgDelaySeconds ?? 0;
     const { tokens: blockchainTokens, networkConfig } = request.server as FastifyInstance;
+
+    logKey = `[op:swap:${channel_user_id}:${inputCurrency}:${outputCurrency}:${amount}]`;
 
     const tokensData: swapTokensData = getSwapTokensData(
       networkConfig,
@@ -134,13 +140,22 @@ export const swap = async (
     let validationError: string = await validateInputs(request.body, tokensData);
 
     if (validationError) {
-      return await returnErrorResponse('swap', '', reply, 400, validationError);
+      Logger.error('swap', logKey, `Invalid swap request: ${validationError}`);
+      // must return 200, so the bot displays the message instead of staying silent!
+      return await returnErrorResponseAsSuccess(
+        'swap',
+        logKey,
+        reply,
+        'Error making swap',
+        false,
+        channel_user_id,
+        validationError
+      );
     }
 
     /* ***************************************************** */
     /* 2. swap: check user has wallet                        */
     /* ***************************************************** */
-    logKey = `[op:swap:${channel_user_id}:${inputCurrency}:${outputCurrency}:${amount}]`;
     const fromUser: IUser | null = await getUser(channel_user_id);
     if (!fromUser) {
       const { message: walletNotCreatedMessage } = await getNotificationTemplate(

--- a/src/controllers/transactionController.ts
+++ b/src/controllers/transactionController.ts
@@ -44,6 +44,7 @@ import {
 import { securityService } from '../services/securityService';
 import { sendTransferUserOperation } from '../services/transferService';
 import {
+  addWalletToUser,
   closeOperation,
   getOrCreateUser,
   getUser,
@@ -777,7 +778,45 @@ export const makeTransaction = async (
       const chatterpayProxyAddress: string = networkConfig.contracts.chatterPayAddress;
       const { factoryAddress } = networkConfig.contracts;
       toUser = await getOrCreateUser(to, chatterpayProxyAddress, factoryAddress);
-      toAddress = toUser.wallets[0].wallet_proxy;
+
+      // A user has a different proxy on every chain, so their wallet on another
+      // chain is not an address they control on this one: sending there strands
+      // the funds. Resolve the recipient by the chain the transfer runs on, and
+      // create their wallet here when they joined on a different network —
+      // getOrCreateUser only creates one for brand-new users.
+      let toWallet: IUserWallet | null = getUserWalletByChainId(
+        toUser.wallets,
+        networkConfig.chainId
+      );
+
+      if (!toWallet) {
+        Logger.info(
+          'makeTransaction',
+          logKey,
+          `Recipient ${to} has no wallet on chain ${networkConfig.chainId}, creating one.`
+        );
+        const added = await addWalletToUser(
+          to,
+          networkConfig.chainId,
+          chatterpayProxyAddress,
+          factoryAddress
+        );
+        if (added) {
+          toUser = added.user;
+          toWallet = added.newWallet;
+        }
+      }
+
+      if (!toWallet) {
+        validationError = `Wallet not found for recipient ${to} and chain ${networkConfig.chainId}`;
+        userCreationSpan?.endSpan();
+        rootSpan?.endSpan();
+        Logger.error('makeTransaction', logKey, validationError);
+        // must return 200, so the bot displays the message instead of an error!
+        return await returnSuccessResponse(reply, validationError);
+      }
+
+      toAddress = toWallet.wallet_proxy;
     }
     userCreationSpan?.endSpan();
 

--- a/src/services/swapService.ts
+++ b/src/services/swapService.ts
@@ -1311,21 +1311,37 @@ async function calculateAndValidateAmountOutMin(
       prev.usdValue > current.usdValue ? prev : current
     );
 
-    // Calculate difference from direct reference
-    const differenceFromDirect = ((bestAmount.usdValue - directPriceUSD) / directPriceUSD) * 100;
+    // Measure how far the candidate's *price* sits from the oracle reference, not how
+    // much slippage we chose to tolerate.
+    //
+    // Quoter and Price Feed both return amountOutMin — the expected output with
+    // totalSlippage already subtracted — while directPriceUSD is the raw spot value with
+    // no slippage at all. Comparing them directly measures our own slippage: the
+    // difference is always about -totalSlippage, so the check below could never pass
+    // whenever slippage exceeded the threshold, on any chain and for any amount. Undo
+    // the slippage first so the threshold measures what it is meant to catch — a pool
+    // whose price has drifted away from the oracle. Direct Price is the reference itself
+    // and carries no slippage, so nothing is undone for it.
+    const slippageFactor = 1 - totalSlippage / 10000;
+    const bestPriceUSD =
+      bestAmount.method === 'Direct Price' || slippageFactor <= 0
+        ? bestAmount.usdValue
+        : bestAmount.usdValue / slippageFactor;
+
+    const differenceFromDirect = ((bestPriceUSD - directPriceUSD) / directPriceUSD) * 100;
 
     Logger.info(
       'calculateAndValidateAmountOutMin',
       logKey,
       `Best method: ${bestAmount.method}, amount: ${bestAmount.amount}, Value: ${bestAmount.usdValue.toFixed(6)} USD, ` +
-        `Difference from direct: ${differenceFromDirect.toFixed(2)}%`
+        `Price before slippage: ${bestPriceUSD.toFixed(6)} USD, Difference from direct: ${differenceFromDirect.toFixed(2)}%`
     );
 
     // ONLY throw error if the BEST result is significantly worse than direct price
     if (differenceFromDirect < -SWAP_PRICE_THRESHOLD_PERCENT) {
       const errorMessage =
         `Best available price is ${Math.abs(differenceFromDirect).toFixed(2)}% worse than expected. ` +
-        `Expected: ${directPriceUSD.toFixed(6)} USD, Best available: ${bestAmount.usdValue.toFixed(6)} USD. ` +
+        `Expected: ${directPriceUSD.toFixed(6)} USD, Best available: ${bestPriceUSD.toFixed(6)} USD. ` +
         `Maximum allowed difference: ${SWAP_PRICE_THRESHOLD_PERCENT}%`;
 
       Logger.error('calculateAndValidateAmountOutMin', logKey, errorMessage);


### PR DESCRIPTION
## Changes Related to #728

- Fixed where a transfer to another user actually lands. The recipient's address was taken from the first wallet on their record — the network they first used — rather than their wallet on the network the transfer runs on, so funds could be sent to an address the recipient does not control there and cannot recover.
- Recipients who already exist but have never operated on the current network now get a wallet created for them on it, instead of falling back to a wallet that belongs to another network.

## Changes Related to #730

- Fixed the origin exemption for the certificate metadata endpoint, which was declared under a path that did not match the route the endpoint is served on. Because the exemption never applied, every request without a browser origin was rejected — which is exactly how explorers, marketplaces and link previews fetch it, so certificates showed up blank everywhere outside our own app. This affected production as well.

## Changes Related to #731
- Fixed the swap price sanity check, which compared the minimum output we accept — slippage already subtracted — against the raw reference price that has none. The difference it measured was therefore our own slippage tolerance, and the check could never pass whenever that tolerance exceeded the allowed difference, on any network and for any amount.
- The allowed difference now applies to real divergence between the pool and the reference price, which is what it was meant to guard against, and the rejection message reports that price instead of the slippage-adjusted minimum.

## Changes Related to #732

- Changed the swap flow so that a request rejected during validation is answered in a way the bot can display. The user is now told that the swap could not be done, instead of being left with no reply at all.
- Added the user and the token pair to the record kept for these rejections, so they can be traced and diagnosed. They were previously stored without any of that context.
- Kept requests that arrive with no content at all being rejected as malformed, since there is no user to answer to in that case. This matches how transfers already behave.